### PR TITLE
Fetch groups & environments in batches.

### DIFF
--- a/api/plugins/inventory/lagoon.py
+++ b/api/plugins/inventory/lagoon.py
@@ -315,7 +315,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             'ansible_ssh_user': namespace,
             'ansible_host': lagoon['ssh_host'],
             'ansible_port': lagoon['ssh_port'],
-            'ansible_connection': 'local',
             'ansible_ssh_common_args': '-T -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no"'
         }
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,1 @@
+gql[requests]

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,1 +1,1 @@
-gql[requests]
+'gql[requests]'

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,1 +1,6 @@
-'gql[requests]'
+gql
+graphql-core<3.3,>=3.2
+yarl<2.0,>=1.6
+requests-toolbelt<1,>=0.9.1
+urllib3>=1.26
+requests<3,>=2.26

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,5 @@
 gql
-graphql-core<3.3,>=3.2
-yarl<2.0,>=1.6
+# Dependencies for the gql requests transport.
 requests-toolbelt<1,>=0.9.1
 urllib3>=1.26
 requests<3,>=2.26


### PR DESCRIPTION
This significantly reduces the number of API calls while also reducing the amount of time to build the inventory.