### PR TITLE
Updated setting of client options to allow passthrough.

### DIFF
--- a/api/plugins/action/env_variable.py
+++ b/api/plugins/action/env_variable.py
@@ -15,17 +15,23 @@ class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
 
         if task_vars is None:
-            task_vars = dict()
+            task_vars = dict(options = {"headers": self._task.args.get('headers', {})})
+            elif task_vars and task_vars.options is None:
+                task_vars.options = dict(
+                        "headers": self._task.args.get('headers', {}),
+                    )
 
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
         display.v("Task args: %s" % self._task.args)
 
+        breakpoint()
+
         lagoon = ApiClient(
             task_vars.get('lagoon_api_endpoint'),
             task_vars.get('lagoon_api_token'),
-            {'headers': self._task.args.get('headers', {})}
+            task_vars.get('options')
         )
 
         type = self._task.args.get('type')

--- a/api/plugins/action/env_variable.py
+++ b/api/plugins/action/env_variable.py
@@ -26,21 +26,20 @@ class ActionModule(ActionBase):
 
         display.v("Task args: %s" % self._task.args)
 
-        breakpoint()
-
-        lagoon = ApiClient(
-            task_vars.get('lagoon_api_endpoint'),
-            task_vars.get('lagoon_api_token'),
-            task_vars.get('options')
-        )
-
+        name = self._task.args.get('name')
         type = self._task.args.get('type')
         type_name = self._task.args.get('type_name')
-        name = self._task.args.get('name')
         state = self._task.args.get('state', 'present')
         value = self._task.args.get('value', None)
         scope = self._task.args.get('scope', None)
         replace_existing = self._task.args.get('replace_existing', False)
+        options = self._task.args.get('options', {'headers': {}})
+
+        lagoon = ApiClient(
+            task_vars.get('lagoon_api_endpoint'),
+            task_vars.get('lagoon_api_token'),
+            options
+        )
 
         # Setting this option will ensure the value has been set, by making
         # additional calls to the API until it matches.

--- a/api/plugins/action/env_variable.py
+++ b/api/plugins/action/env_variable.py
@@ -29,7 +29,7 @@ class ActionModule(ActionBase):
         value = self._task.args.get('value', None)
         scope = self._task.args.get('scope', None)
         replace_existing = self._task.args.get('replace_existing', False)
-        options = self._task.args.get('options', {}})
+        options = self._task.args.get('options', {})
         if not 'headers' in options:
             options['headers'] = {}
 

--- a/api/plugins/action/env_variable.py
+++ b/api/plugins/action/env_variable.py
@@ -29,7 +29,9 @@ class ActionModule(ActionBase):
         value = self._task.args.get('value', None)
         scope = self._task.args.get('scope', None)
         replace_existing = self._task.args.get('replace_existing', False)
-        options = self._task.args.get('options', {'headers': {}})
+        options = self._task.args.get('options', {}})
+        if not 'headers' in options:
+            options['headers'] = {}
 
         lagoon = ApiClient(
             task_vars.get('lagoon_api_endpoint'),

--- a/api/plugins/action/env_variable.py
+++ b/api/plugins/action/env_variable.py
@@ -15,11 +15,7 @@ class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
 
         if task_vars is None:
-            task_vars = dict(options = {"headers": self._task.args.get('headers', {})})
-            elif task_vars and task_vars.options is None:
-                task_vars.options = dict(
-                        "headers": self._task.args.get('headers', {}),
-                    )
+            task_vars = dict()
 
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect

--- a/api/plugins/action/variables.py
+++ b/api/plugins/action/variables.py
@@ -22,14 +22,15 @@ class ActionModule(ActionBase):
 
         display.v("Task args: %s" % self._task.args)
 
+        name = self._task.args.get('name')
+        type = self._task.args.get('type', 'project')
+        options = self._task.args.get('options', {'headers': {}})
+
         lagoon = ApiClient(
             task_vars.get('lagoon_api_endpoint'),
             task_vars.get('lagoon_api_token'),
-            {'headers': self._task.args.get('headers', {})}
+            options
         )
-
-        name = self._task.args.get('name')
-        type = self._task.args.get('type', 'project')
 
         if type == "project":
             result['data'] = lagoon.project_get_variables(name)

--- a/api/plugins/action/variables.py
+++ b/api/plugins/action/variables.py
@@ -24,7 +24,9 @@ class ActionModule(ActionBase):
 
         name = self._task.args.get('name')
         type = self._task.args.get('type', 'project')
-        options = self._task.args.get('options', {'headers': {}})
+        options = self._task.args.get('options', {})
+        if not 'headers' in options:
+            options['headers'] = {}
 
         lagoon = ApiClient(
             task_vars.get('lagoon_api_endpoint'),

--- a/api/plugins/module_utils/api_client.py
+++ b/api/plugins/module_utils/api_client.py
@@ -618,7 +618,6 @@ class ApiClient:
 
     def make_api_call(self, payload):
         # display.v("API call payload: %s" % payload)
-        raise Exception(self.options.get('options'))
         try:
             response = open_url(self.options.get('endpoint'), data=payload,
                                 validate_certs=self.options.get(

--- a/api/plugins/module_utils/api_client.py
+++ b/api/plugins/module_utils/api_client.py
@@ -618,6 +618,7 @@ class ApiClient:
 
     def make_api_call(self, payload):
         # display.v("API call payload: %s" % payload)
+        raise Exception(self.options.get('options'))
         try:
             response = open_url(self.options.get('endpoint'), data=payload,
                                 validate_certs=self.options.get(


### PR DESCRIPTION
### Changes
1. Updating the setting of the ApiClient options to handle configurable timeout.

I've tested this using the changes in this CMDB PR https://github.com/dpc-sdp/sdp-cmdb/pull/599, which I'm going to leave in draft until this work is merged.