### PR TITLE
Use new client in as many places as possible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Run ansible-test
 
 on:
   push:
-    branches: [ main, feature/refactor-use-new-client ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          path: 'ansible_collections/lagoon/api'
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,5 @@ jobs:
         run: python -m pip install ansible pytest pytest-forked
 
       - name: Run unit tests
-        run: |
-          pwd
-          ls -l
-          ansible-test units -v --requirements
+        run: ansible-test units -v --requirements --python ${{ matrix.python-version }}
         working-directory: ./ansible_collections/lagoon/api

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,14 @@ jobs:
         run: ansible-test units -v --requirements --python ${{ matrix.python-version }}
         working-directory: ./ansible_collections/lagoon/api
 
+      - name: Publish test report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          check_name: Ansible tests - python${{ matrix.python-version }}
+          report_paths: 'ansible_collections/lagoon/api/tests/output/junit/*.xml'
+          detailed_summary: true
+
       - name: Upload test results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Run ansible-test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  ansible-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: python -m pip install ansible pytest pytest-forked
+
+      - name: Run unit tests
+        run: ansible-test units -v --requirements

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Run ansible-test
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, feature/refactor-use-new-client ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        # python-version: [ '3.8', '3.9', '3.10', '3.11' ]
-        python-version: [ '3.8' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
       - name: Checkout
@@ -36,3 +35,9 @@ jobs:
       - name: Run unit tests
         run: ansible-test units -v --requirements --python ${{ matrix.python-version }}
         working-directory: ./ansible_collections/lagoon/api
+
+      - name: Publish test report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: 'ansible_collections/lagoon/api/tests/output/junit/*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        # python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8' ]
 
     steps:
       - name: Checkout
@@ -33,5 +34,8 @@ jobs:
         run: python -m pip install ansible pytest pytest-forked
 
       - name: Run unit tests
-        run: ansible-test units -v --requirements
+        run: |
+          pwd
+          ls -l
+          ansible-test units -v --requirements
         working-directory: ./ansible_collections/lagoon/api

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,4 @@ jobs:
 
       - name: Run unit tests
         run: ansible-test units -v --requirements
+        working-directory: ./ansible_collections/lagoon/api

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
 
     steps:
       - name: Checkout
@@ -36,8 +36,10 @@ jobs:
         run: ansible-test units -v --requirements --python ${{ matrix.python-version }}
         working-directory: ./ansible_collections/lagoon/api
 
-      - name: Publish test report
-        uses: mikepenz/action-junit-report@v3
-        if: always()
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
         with:
-          report_paths: 'ansible_collections/lagoon/api/tests/output/junit/*.xml'
+          name: test-results-${{ matrix.python-version }}
+          path: ansible_collections/lagoon/api/tests/output/junit/*.xml
+        # Use always() to publish test results even when there are failures.
+        if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         uses: mikepenz/action-junit-report@v3
         if: always()
         with:
-          check_name: Ansible tests - python${{ matrix.python-version }}
+          check_name: ansible-test (${{ matrix.python-version }}) results
           report_paths: 'ansible_collections/lagoon/api/tests/output/junit/*.xml'
           detailed_summary: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          path: 'ansible_collections/lagoon/api'
+          path: 'ansible_collections/lagoon'
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+api/tests/output
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM alpine AS builder
+
+ENV PYENV_ROOT=/opt/.pyenv
+
+ENV PATH="$PYENV_ROOT/bin:$PATH"
+ENV PATH="$PYENV_ROOT/versions/3.11.0/bin:$PATH"
+ENV PATH="$PYENV_ROOT/versions/3.10.8/bin:$PATH"
+ENV PATH="$PYENV_ROOT/versions/3.9.15/bin:$PATH"
+ENV PATH="$PYENV_ROOT/versions/3.8.15/bin:$PATH"
+
+RUN apk add --no-cache bash git \
+    && git clone https://github.com/pyenv/pyenv.git $PYENV_ROOT \
+    && apk add --no-cache \
+        build-base libffi-dev openssl-dev bzip2-dev \
+        zlib-dev xz-dev readline-dev sqlite-dev tk-dev \
+    && pyenv install 3.8.15 \
+    && pyenv install 3.9.15 \
+    && pyenv install 3.10.8 \
+    && pyenv install 3.11.0 \
+    && python3.8 -m pip install ansible pytest pytest-forked \
+    && python3.9 -m pip install ansible pytest pytest-forked \
+    && python3.10 -m pip install ansible pytest pytest-forked \
+    && python3.11 -m pip install ansible pytest pytest-forked
+
+FROM alpine
+
+ENV PYENV_ROOT=/opt/.pyenv
+
+ENV PATH="$PYENV_ROOT/bin:$PATH"
+ENV PATH="$PYENV_ROOT/versions/3.11.0/bin:$PATH"
+ENV PATH="$PYENV_ROOT/versions/3.10.8/bin:$PATH"
+ENV PATH="$PYENV_ROOT/versions/3.9.15/bin:$PATH"
+ENV PATH="$PYENV_ROOT/versions/3.8.15/bin:$PATH"
+
+COPY --from=builder $PYENV_ROOT $PYENV_ROOT
+
+RUN apk add --no-cache libffi
+
+ENTRYPOINT [ "ansible-test" ]

--- a/README.md
+++ b/README.md
@@ -5,3 +5,27 @@ This repository contains collections related to the [Lagoon](https://github.com/
 The following collections are available:
 
 * [api](/api)
+
+## Update graphql schema
+This uses the Lagoon CLI to acquire an updated token, then uses the `gql-cli` to download the schema.
+
+```sh
+# Install requirements.
+python3 -m pip install -r api/requirements.txt
+
+# Ensure a fresh token is available.
+lagoon -l amazeeio whoami
+export LAGOON_TOKEN=$(yq -r '.lagoons.amazeeio.token' ~/.lagoon.yml)
+
+# Download the schema.
+gql-cli https://api.lagoon.amazeeio.cloud/graphql --print-schema \
+    --header Authorization:"Bearer $LAGOON_TOKEN" > api/tests/common/schema.graphql
+```
+
+## Run unit tests
+```sh
+docker run --rm -it -v \
+    $PWD/api:/usr/share/collections/ansible_collections/lagoon/api \
+    -w /usr/share/collections/ansible_collections/lagoon/api \
+    ghcr.io/salsadigitalauorg/ansible-test:latest units -v --requirements
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Ansible Collection - lagoon
+[![tests](https://github.com/salsadigitalauorg/lagoon_ansible_collection/actions/workflows/test.yml/badge.svg)](https://github.com/salsadigitalauorg/lagoon_ansible_collection/actions/workflows/test.yml)
 
 This repository contains collections related to the [Lagoon](https://github.com/uselagoon/lagoon) application delivery platform.
 
@@ -24,8 +25,6 @@ gql-cli https://api.lagoon.amazeeio.cloud/graphql --print-schema \
 
 ## Run unit tests
 ```sh
-docker run --rm -it -v \
-    $PWD/api:/usr/share/collections/ansible_collections/lagoon/api \
-    -w /usr/share/collections/ansible_collections/lagoon/api \
-    ghcr.io/salsadigitalauorg/ansible-test:latest units -v --requirements
+docker-compose build
+docker-compose run --rm test units -v --requirements
 ```

--- a/api/galaxy.yml
+++ b/api/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: lagoon
 name: api
-version: 1.1.0
+version: 1.2.0
 readme: README.md
 
 authors:

--- a/api/playbooks/deploy_branch.yml
+++ b/api/playbooks/deploy_branch.yml
@@ -1,0 +1,24 @@
+- name: Deploy project branch.
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  roles:
+    - lagoon.api.common
+  tasks:
+    - include_role:
+        name: lagoon.api.token
+
+    - name: Trigger staggered deployment.
+      lagoon.api.deploy:
+        project: '{{ deploy_project }}'
+        branch: '{{ deploy_branch }}'
+        stagger: 5
+      throttle: 1
+
+    - name: Wait for deployment to complete.
+      lagoon.api.last_deploy:
+        project: '{{ deploy_project }}'
+        branch: '{{ deploy_branch }}'
+        wait: true
+        retries: 60

--- a/api/playbooks/project_metadata.yml
+++ b/api/playbooks/project_metadata.yml
@@ -1,0 +1,13 @@
+- name: Fetch project metadata.
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  roles:
+    - lagoon.api.common
+  tasks:
+    - include_role:
+        name: lagoon.api.token
+
+    - name: Retrieve project metadata.
+      debug: msg="{{ lookup('lagoon.api.metadata', project=project_name) }}"

--- a/api/playbooks/query.yml
+++ b/api/playbooks/query.yml
@@ -1,0 +1,66 @@
+- name: Execute an arbitratry query.
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  roles:
+    - lagoon.api.common
+  tasks:
+    - include_role:
+        name: lagoon.api.token
+
+    - name: Query specific fields for all projects.
+      lagoon.api.query:
+        query: allProjects
+        mainType: Project
+        fields:
+          - id
+          - name
+      register: query_results
+      when: project_name is not defined
+
+    - debug: var=query_results
+      when: project_name is not defined
+
+    - name: Query specific fields for a project.
+      lagoon.api.query:
+        query: projectByName
+        mainType: Project
+        args:
+          name: '{{ project_name }}'
+        fields:
+          - id
+          - name
+          - branches
+          - metadata
+        subFields:
+          kubernetes:
+            type: Kubernetes
+            fields:
+              - id
+              - name
+      register: query_results
+      when: project_name is defined
+
+    - debug: var=query_results
+      when: project_name is defined
+
+    - name: Query variables for a project.
+      lagoon.api.query:
+        query: projectByName
+        mainType: Project
+        args:
+          name: '{{ project_name }}'
+        subFields:
+          envVariables:
+            type: EnvKeyValue
+            fields:
+              - id
+              - name
+              - value
+              - scope
+      register: query_results
+      when: project_name is defined
+
+    - debug: var=query_results
+      when: project_name is defined

--- a/api/plugins/action/__init__.py
+++ b/api/plugins/action/__init__.py
@@ -1,0 +1,12 @@
+from ansible.plugins.action import ActionBase
+from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
+
+
+class LagoonActionBase(ActionBase):
+
+    def createClient(self, task_vars):
+        self.client = GqlClient(
+            self._templar.template(task_vars.get('lagoon_api_endpoint')).strip(),
+            self._templar.template(task_vars.get('lagoon_api_token')).strip(),
+            self._task.args.get('headers', {})
+        )

--- a/api/plugins/action/__init__.py
+++ b/api/plugins/action/__init__.py
@@ -8,5 +8,6 @@ class LagoonActionBase(ActionBase):
         self.client = GqlClient(
             self._templar.template(task_vars.get('lagoon_api_endpoint')).strip(),
             self._templar.template(task_vars.get('lagoon_api_token')).strip(),
-            self._task.args.get('headers', {})
+            self._task.args.get('headers', {}),
+            self._display,
         )

--- a/api/plugins/action/deploy.py
+++ b/api/plugins/action/deploy.py
@@ -1,15 +1,9 @@
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
-
 import time
-from ansible.plugins.action import ActionBase
-from ansible.utils.display import Display
-from ansible_collections.lagoon.api.plugins.module_utils.api_client import ApiClient
-
-display = Display()
+from ansible_collections.lagoon.api.plugins.action import LagoonActionBase
+from ansible_collections.lagoon.api.plugins.module_utils.gqlEnvironment import Environment
 
 
-class ActionModule(ActionBase):
+class ActionModule(LagoonActionBase):
 
     def run(self, tmp=None, task_vars=None):
 
@@ -19,22 +13,19 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
-        display.v("Task args: %s" % self._task.args)
+        self._display.v("Task args: %s" % self._task.args)
 
-        lagoon = ApiClient(
-            task_vars.get('lagoon_api_endpoint'),
-            task_vars.get('lagoon_api_token'),
-            {'headers': self._task.args.get('headers', {})}
-        )
+        self.createClient(task_vars)
+        lagoonEnvironment = Environment(self.client)
 
-        result['deploy_status'] = lagoon.project_deploy(
+        result['deploy_status'] = lagoonEnvironment.deployBranch(
             self._task.args.get('project'),
             self._task.args.get('branch'),
             self._task.args.get('wait', False),
             self._task.args.get('delay', 60),
             self._task.args.get('retries', 30)
         )
-        display.v("Deploy status: %s" % result['deploy_status'])
+        self._display.v("Deploy status: %s" % result['deploy_status'])
 
         # This is a way to delay concurrent deployments to Lagoon.
         stagger = self._task.args.get('stagger', 0)

--- a/api/plugins/action/deploy_bulk.py
+++ b/api/plugins/action/deploy_bulk.py
@@ -50,7 +50,6 @@ def deploy_bulk(client: GqlClient, build_vars: list, name: str, envs: list) -> d
             "envs": envs,
         }
     )
-    display.v(f"GraphQL query result: {res}")
 
     if 'errors' in res:
         raise AnsibleError("Unable to create bulk deployment.", res['errors'])

--- a/api/plugins/action/info.py
+++ b/api/plugins/action/info.py
@@ -7,12 +7,8 @@ EXAMPLES = r'''
 '''
 
 from ansible.errors import AnsibleError
-from ansible.utils.display import Display
 from ansible_collections.lagoon.api.plugins.action import LagoonActionBase
 from ansible_collections.lagoon.api.plugins.module_utils.gqlEnvironment import Environment
-
-display = Display()
-
 
 class ActionModule(LagoonActionBase):
 
@@ -48,7 +44,7 @@ class ActionModule(LagoonActionBase):
 
         lagoonEnvironment.withCluster().withProject()
         if len(lagoonEnvironment.errors):
-            display.warning(
+            self._display.warning(
                 f"The query partially succeeded, but the following errors were encountered:\n{ lagoonEnvironment.errors }")
 
         result['result'] = lagoonEnvironment.environments[0]

--- a/api/plugins/action/list.py
+++ b/api/plugins/action/list.py
@@ -29,8 +29,8 @@ class ActionModule(LagoonActionBase):
             result['failed'] = True
             self._display.v("Only 'project' is supported")
         else:
-            lagoonProject = Project(self.client, {'batch_size': 20}).all(
-            ).withEnvironments()
+            lagoonProject = Project(self.client).all(
+            ).withEnvironments(batch_size=50)
             if len(lagoonProject.errors):
                 if not len(lagoonProject.projects):
                     raise AnsibleError(f"Unable to get projects.")

--- a/api/plugins/action/query.py
+++ b/api/plugins/action/query.py
@@ -45,8 +45,6 @@ EXAMPLES = r'''
 '''
 
 from ansible_collections.lagoon.api.plugins.action import LagoonActionBase
-from gql.dsl import DSLQuery, dsl_gql
-from graphql import print_ast
 
 class ActionModule(LagoonActionBase):
 
@@ -69,8 +67,6 @@ class ActionModule(LagoonActionBase):
         with self.client:
             queryObj = self.client.build_dynamic_query(
                 query, mainType, args, fields, subFields)
-            query_ast = dsl_gql(DSLQuery(queryObj))
-            self._display.vvvv(f"Built query: \n{print_ast(query_ast)}")
             res = self.client.execute_query_dynamic(queryObj)
             result['result'] = res[query]
         return result

--- a/api/plugins/action/query.py
+++ b/api/plugins/action/query.py
@@ -1,0 +1,76 @@
+EXAMPLES = r'''
+- name: Query specific fields for all projects.
+  lagoon.api.query:
+    query: allProjects
+    mainType: Project
+    fields:
+      - id
+      - name
+  register: query_results
+
+- name: Query specific fields for a project.
+  lagoon.api.query:
+    query: projectByName
+    mainType: Project
+    args:
+      name: '{{ project_name }}'
+    fields:
+      - id
+      - name
+      - branches
+      - metadata
+    subFields:
+      kubernetes:
+        type: Kubernetes
+        fields:
+          - id
+          - name
+  register: query_results
+
+- name: Query variables for a project.
+  lagoon.api.query:
+    query: projectByName
+    mainType: Project
+    args:
+      name: '{{ project_name }}'
+    subFields:
+      envVariables:
+        type: EnvKeyValue
+        fields:
+          - id
+          - name
+          - value
+          - scope
+  register: query_results
+'''
+
+from ansible_collections.lagoon.api.plugins.action import LagoonActionBase
+from gql.dsl import DSLQuery, dsl_gql
+from graphql import print_ast
+
+class ActionModule(LagoonActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        self.createClient(task_vars)
+
+        query = self._task.args.get('query')
+        mainType = self._task.args.get('mainType')
+        args = self._task.args.get('args', {})
+        fields = self._task.args.get('fields', [])
+        subFields = self._task.args.get('subFields', {})
+
+        with self.client:
+            queryObj = self.client.build_dynamic_query(
+                query, mainType, args, fields, subFields)
+            query_ast = dsl_gql(DSLQuery(queryObj))
+            self._display.vvvv(f"Built query: \n{print_ast(query_ast)}")
+            res = self.client.execute_query_dynamic(queryObj)
+            result['result'] = res[query]
+        return result

--- a/api/plugins/action/user_group.py
+++ b/api/plugins/action/user_group.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
-
 EXAMPLES = r'''
 - name: Add user to group.
   lagoon.api.user_group:
@@ -12,11 +9,10 @@ EXAMPLES = r'''
 '''
 
 from ansible.errors import AnsibleError
-from ansible.plugins.action import ActionBase
-from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
+from ansible_collections.lagoon.api.plugins.action import LagoonActionBase
 
 
-class ActionModule(ActionBase):
+class ActionModule(LagoonActionBase):
 
     def run(self, tmp=None, task_vars=None):
 
@@ -28,11 +24,7 @@ class ActionModule(ActionBase):
 
         self._display.v("Task args: %s" % self._task.args)
 
-        self.lagoon = GqlClient(
-            task_vars.get('lagoon_api_endpoint'),
-            task_vars.get('lagoon_api_token'),
-            self._task.args.get('headers', {})
-        )
+        self.createClient(task_vars)
 
         email = self._task.args.get('email')
         group_name = self._task.args.get('group')
@@ -64,7 +56,7 @@ class ActionModule(ActionBase):
         return result
 
     def user_add_group(self, email: str, group: str, role: str) -> dict:
-        res = self.lagoon.execute_query(
+        res = self.client.execute_query(
             """
             mutation group(
                 $email: String!
@@ -89,7 +81,7 @@ class ActionModule(ActionBase):
         return res['addUserToGroup']['id']
 
     def user_remove_group(self, email: str, group: str):
-        res = self.lagoon.execute_query(
+        res = self.client.execute_query(
             """
             mutation group(
                 $email: String!

--- a/api/plugins/action/whoami.py
+++ b/api/plugins/action/whoami.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
-
 EXAMPLES = r'''
 - name: Verify the user.
   lagoon.api.whoami: {}
@@ -9,8 +6,8 @@ EXAMPLES = r'''
 '''
 
 from ansible.errors import AnsibleError
-from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
+from ansible_collections.lagoon.api.plugins.action import LagoonActionBase
 from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
 
 display = Display()
@@ -39,7 +36,8 @@ def whoAmI(client: GqlClient) -> dict:
         raise AnsibleError(f"Unable to get user information.")
     return res['me']
 
-class ActionModule(ActionBase):
+
+class ActionModule(LagoonActionBase):
 
     def run(self, tmp=None, task_vars=None):
 
@@ -49,13 +47,9 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
-        display.v("Task args: %s" % self._task.args)
+        self._display.v("Task args: %s" % self._task.args)
 
-        lagoon = GqlClient(
-            self._templar.template(task_vars.get('lagoon_api_endpoint')).strip(),
-            self._templar.template(task_vars.get('lagoon_api_token')).strip(),
-            self._task.args.get('headers', {})
-        )
+        self.createClient(task_vars)
 
-        result['result'] = whoAmI(lagoon)
+        result['result'] = whoAmI(self.client)
         return result

--- a/api/plugins/lookup/__init__.py
+++ b/api/plugins/lookup/__init__.py
@@ -1,0 +1,13 @@
+from ansible.plugins.lookup import LookupBase
+from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
+
+
+class LagoonLookupBase(LookupBase):
+
+    def createClient(self):
+        self.client = GqlClient(
+            self._templar.template(self.get_option('lagoon_api_endpoint')),
+            self._templar.template(self.get_option('lagoon_api_token')),
+            self.get_option('headers', {}),
+            self._display,
+        )

--- a/api/plugins/lookup/all_environments.py
+++ b/api/plugins/lookup/all_environments.py
@@ -58,14 +58,14 @@ class LookupModule(LagoonLookupBase):
 
     self.createClient()
 
-    lagoonEnvironment = Environment(self.client, {'batch_size': 50}).all()
+    lagoonEnvironment = Environment(self.client).all()
     if not len(lagoonEnvironment.environments):
       if len(lagoonEnvironment.errors):
         raise AnsibleError(
             f"Unable to fetch environments; encountered the following errors: {lagoonEnvironment.errors}")
       return ret
 
-    lagoonEnvironment.withCluster().withVariables()
+    lagoonEnvironment.withCluster(batch_size=50).withVariables(batch_size=50)
     if len(lagoonEnvironment.errors):
       self._display.warning(
           f"The query partially succeeded, but the following errors were encountered:\n{ lagoonEnvironment.errors }")

--- a/api/plugins/lookup/all_projects.py
+++ b/api/plugins/lookup/all_projects.py
@@ -58,14 +58,14 @@ class LookupModule(LagoonLookupBase):
 
     self.createClient()
 
-    lagoonProject = Project(self.client, {'batch_size': 20}).all()
+    lagoonProject = Project(self.client).all()
     if not len(lagoonProject.projects):
       if len(lagoonProject.errors):
         raise AnsibleError(
             f"Unable to fetch projects; encountered the following errors: {lagoonProject.errors}")
       return ret
 
-    lagoonProject.withCluster().withEnvironments()
+    lagoonProject.withCluster(batch_size=50).withEnvironments(batch_size=50)
     if len(lagoonProject.errors):
       self._display.warning(
           f"The query partially succeeded, but the following errors were encountered:\n{ lagoonProject.errors }")

--- a/api/plugins/lookup/environment.py
+++ b/api/plugins/lookup/environment.py
@@ -1,5 +1,6 @@
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
+from ansible.errors import AnsibleError
+from ansible_collections.lagoon.api.plugins.module_utils.gqlEnvironment import Environment
+from ansible_collections.lagoon.api.plugins.lookup import LagoonLookupBase
 
 DOCUMENTATION = """
   name: environment
@@ -46,17 +47,11 @@ DOCUMENTATION = """
 
 EXAMPLES = """
 - name: retrieve a environment's information
-  debug: msg="{{ lookup('lagoon.api.environment', 'vanilla-govcms9-beta-master') }}"
+  debug: msg="{{ lookup('lagoon.api.environment', environment_ns) }}"
 """
 
-from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
-from ansible_collections.lagoon.api.plugins.module_utils.gqlEnvironment import Environment
-from ansible.plugins.lookup import LookupBase
-from ansible.utils.display import Display
 
-display = Display()
-
-class LookupModule(LookupBase):
+class LookupModule(LagoonLookupBase):
 
     def run(self, terms, variables=None, **kwargs):
 
@@ -64,23 +59,22 @@ class LookupModule(LookupBase):
 
         self.set_options(var_options=variables, direct=kwargs)
 
-        lagoon = GqlClient(
-            self._templar.template(self.get_option('lagoon_api_endpoint')),
-            self._templar.template(self.get_option('lagoon_api_token')),
-            self.get_option('headers', {})
-        )
+        self.createClient()
 
-        lagoonEnvironment = Environment(lagoon)
+        lagoonEnvironment = Environment(self.client)
 
         for term in terms:
             lagoonEnvironment.byNs(term)
             if not len(lagoonEnvironment.environments):
+                if len(lagoonEnvironment.errors):
+                    raise AnsibleError(
+                        f"Unable to fetch environment {term}; encountered the following errors: {lagoonEnvironment.errors}")
                 return ret
 
             lagoonEnvironment.withCluster().withVariables()
             lagoonEnvironment.withProject().withDeployments()
             if len(lagoonEnvironment.errors):
-                display.warning(
+                self._display.warning(
                     f"The query partially succeeded, but the following errors were encountered:\n{ lagoonEnvironment.errors }")
             ret.extend(lagoonEnvironment.environments)
 

--- a/api/plugins/lookup/group.py
+++ b/api/plugins/lookup/group.py
@@ -1,8 +1,5 @@
-from __future__ import (absolute_import, division, print_function)
 from ansible_collections.lagoon.api.plugins.module_utils.api_client import ApiClient
 from ansible.plugins.lookup import LookupBase
-from ansible.utils.display import Display
-__metaclass__ = type
 
 DOCUMENTATION = """
   name: group
@@ -53,9 +50,6 @@ EXAMPLES = """
 - name: retrieve a groups information
   debug: msg="{{ lookup('lagoon.api.group', 'my-group-name') }}"
 """
-
-
-display = Display()
 
 
 class LookupModule(LookupBase):

--- a/api/plugins/lookup/metadata.py
+++ b/api/plugins/lookup/metadata.py
@@ -1,5 +1,7 @@
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
+import json
+from ansible_collections.lagoon.api.plugins.module_utils.gqlProject import Project
+from ansible_collections.lagoon.api.plugins.lookup import LagoonLookupBase
+from ansible.errors import AnsibleError
 
 DOCUMENTATION = """
   name: metadata
@@ -51,52 +53,31 @@ DOCUMENTATION = """
 
 EXAMPLES = """
 - name: retrieve a project's metadata
-  debug: msg="{{ lookup('lagoon.api.metadata', project='vanilla-govcms9-beta') }}"
+  debug: msg="{{ lookup('lagoon.api.metadata', project=project_name) }}"
 
 - name: retrieve a project's status
-  debug: msg="{{ lookup('lagoon.api.metadata', 'project-status', project='vanilla-govcms9-beta') }}"
+  debug: msg="{{ lookup('lagoon.api.metadata', 'project-status', project=project_name) }}"
 """
 
-import json
-from ansible.errors import AnsibleError
-from ansible.utils.display import Display
-from ansible.plugins.lookup import LookupBase
-from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
-
-display = Display()
-
-
-def get_metadata(client: GqlClient, project_name: str) -> dict:
-  with client as (_, ds):
-    res = client.execute_query_dynamic(
-        ds.Query.projectByName(name=project_name).select(
-            ds.Project.metadata,
-        )
-    )
-
-    display.v(f"GraphQL query result: {res}")
-    if res['projectByName'] == None:
-      raise AnsibleError(
-          f"Unable to get metadata for project {project_name}; please make sure the project name is correct")
-
-    return json.loads(res['projectByName']['metadata'])
-
-class LookupModule(LookupBase):
+class LookupModule(LagoonLookupBase):
 
   def run(self, terms, variables=None, **kwargs):
 
     ret = []
 
     self.set_options(var_options=variables, direct=kwargs)
-    lagoon = GqlClient(
-        self._templar.template(self.get_option('lagoon_api_endpoint')),
-        self._templar.template(self.get_option('lagoon_api_token')),
-        self.get_option('headers', {})
-    )
+
+    self.createClient()
+
     project = self.get_option('project')
 
-    metadata = get_metadata(lagoon, project)
-    display.v(f"metadata: {metadata}")
+    lagoonProject = Project(self.client).byName(project, ['metadata'])
+    if not len(lagoonProject.projects):
+        raise AnsibleError(
+            f"Unable to get metadata for project {project}; please make sure the project name is correct")
+
+    metadata = json.loads(lagoonProject.projects[0]['metadata'])
+    self._display.v(f"metadata: {metadata}")
 
     if not len(terms):
       for k in metadata:

--- a/api/plugins/lookup/project.py
+++ b/api/plugins/lookup/project.py
@@ -1,11 +1,7 @@
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
-
-from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
-from ansible_collections.lagoon.api.plugins.module_utils.gqlProject import Project
-from ansible.plugins.lookup import LookupBase
-from ansible.utils.display import Display
 from ansible.errors import AnsibleError
+from ansible_collections.lagoon.api.plugins.lookup import LagoonLookupBase
+from ansible_collections.lagoon.api.plugins.module_utils.gqlProject import Project
+from ansible_collections.lagoon.api.plugins.module_utils.gqlEnvironment import Environment
 
 DOCUMENTATION = """
   name: project
@@ -56,37 +52,14 @@ DOCUMENTATION = """
 
 EXAMPLES = """
 - name: retrieve a project's information
-  debug: msg="{{ lookup('lagoon.api.project', 'vanilla-govcms9-beta') }}"
+  debug: msg="{{ lookup('lagoon.api.project', project_name) }}"
 
 - name: retrieve a project's information from an environment
-  debug: msg="{{ lookup('lagoon.api.project', 'vanilla-govcms9-beta-master', from_environment=true) }}"
+  debug: msg="{{ lookup('lagoon.api.project', environment_ns, from_environment=true) }}"
 """
 
-display = Display()
 
-def get_project_from_environment(client: GqlClient, name: str) -> dict:
-  with client as (_, ds):
-    res = client.execute_query_dynamic(
-        ds.Query.environmentByKubernetesNamespaceName(kubernetesNamespaceName=name).select(
-            ds.Environment.project.select(
-                ds.Project.id,
-                ds.Project.name,
-                ds.Project.autoIdle,
-                ds.Project.branches,
-                ds.Project.gitUrl,
-                ds.Project.metadata,
-                ds.Project.productionEnvironment,
-                ds.Project.standbyProductionEnvironment,
-            )
-        )
-    )
-    display.v(f"GraphQL query result: {res}")
-    if res['environmentByKubernetesNamespaceName']['project'] == None:
-      raise AnsibleError(
-          f"Unable to get project details for environment {name}; please make sure the environment name is correct")
-    return res['environmentByKubernetesNamespaceName']['project']
-
-class LookupModule(LookupBase):
+class LookupModule(LagoonLookupBase):
 
   def run(self, terms, variables=None, **kwargs):
 
@@ -94,28 +67,30 @@ class LookupModule(LookupBase):
 
     self.set_options(var_options=variables, direct=kwargs)
 
-    lagoon = GqlClient(
-        self._templar.template(self.get_option('lagoon_api_endpoint')),
-        self._templar.template(self.get_option('lagoon_api_token')),
-        self.get_option('headers', {})
-    )
+    self.createClient()
 
-    lagoonProject = Project(lagoon)
+    lagoonProject = Project(self.client)
+    lagoonEnvironment = Environment(self.client)
 
     for term in terms:
       if self.get_option('from_environment'):
-        project = get_project_from_environment(lagoon, term)
-        ret.append(project)
+        lagoonEnvironment.byNs(term, ['id'])
+        if not len(lagoonEnvironment.environments):
+          raise AnsibleError(
+              f"Unable to fetch environment {term}; errors: {lagoonEnvironment.errors}")
+
+        lagoonEnvironment.withProject()
+        lagoonProject.projects = [lagoonEnvironment.environments[0]['project']]
       else:
         lagoonProject.byName(term)
         if not len(lagoonProject.projects):
             return ret
 
-        lagoonProject.withCluster().withEnvironments()
-        lagoonProject.withDeployTargetConfigs().withVariables().withGroups()
-        if len(lagoonProject.errors):
-          display.warning(
-              f"The query partially succeeded, but the following errors were encountered:\n{ lagoonProject.errors }")
-        ret.extend(lagoonProject.projects)
+      lagoonProject.withCluster().withEnvironments()
+      lagoonProject.withDeployTargetConfigs().withVariables().withGroups()
+      if len(lagoonProject.errors):
+        self._display.warning(
+            f"The query partially succeeded, but the following errors were encountered:\n{ lagoonProject.errors }")
+      ret.extend(lagoonProject.projects)
 
     return ret

--- a/api/plugins/lookup/var.py
+++ b/api/plugins/lookup/var.py
@@ -1,10 +1,7 @@
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
-
-from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
-from ansible.plugins.lookup import LookupBase
-from ansible.utils.display import Display
 from ansible.errors import AnsibleError
+from ansible_collections.lagoon.api.plugins.lookup import LagoonLookupBase
+from ansible_collections.lagoon.api.plugins.module_utils.gqlEnvironment import Environment
+from ansible_collections.lagoon.api.plugins.module_utils.gqlProject import Project
 
 DOCUMENTATION = """
   name: var
@@ -62,84 +59,52 @@ DOCUMENTATION = """
 EXAMPLES = """
 - name: lookup a project's variables
   debug: msg="{{ item }}"
-  loop: "{{ lookup('lagoon.api.var', 'vanilla-govcms9-beta') }}"
+  loop: "{{ lookup('lagoon.api.var', project_name) }}"
 
 - name: retrieve a project's variables as dict
-  debug: msg="{{ lookup('lagoon.api.var', 'vanilla-govcms9-beta', return_dict=true) }}"
+  debug: msg="{{ lookup('lagoon.api.var', project_name, return_dict=true) }}"
 
 - name: retrieve a specific variable for a project
-  debug: msg='{{ lookup('lagoon.api.var', 'vanilla-govcms9-beta', var_name='CLAMAV_HOST') }}'
+  debug: msg='{{ lookup('lagoon.api.var', project_name, var_name=project_var_name) }}'
 
 - name: retrieve variables for a project environment
-  debug: msg='{{ lookup('lagoon.api.var', 'vanilla-govcms9-beta', environment='master') }}'
+  debug: msg='{{ lookup('lagoon.api.var', project_name, environment='master') }}'
 
 - name: retrieve a specific variable for a project environment
-  debug: msg='{{ lookup('lagoon.api.var', 'vanilla-govcms9-beta', environment='master', var_name='GOVCMS_TEST_CANARY') }}'
+  debug: msg='{{ lookup('lagoon.api.var', project_name, environment='master', var_name=project_var_name) }}'
 """
 
 
-display = Display()
-
-def get_vars_from_environment(client: GqlClient, name: str) -> dict:
-  with client as (_, ds):
-    res = client.execute_query_dynamic(
-        ds.Query.environmentByKubernetesNamespaceName(kubernetesNamespaceName=name).select(
-            ds.Environment.envVariables.select(
-                ds.EnvKeyValue.id,
-                ds.EnvKeyValue.name,
-                ds.EnvKeyValue.value,
-                ds.EnvKeyValue.scope,
-            )
-        )
-    )
-    display.v(f"GraphQL query result: {res}")
-    if res['environmentByKubernetesNamespaceName'] == None:
-        raise AnsibleError(
-            f"Unable to get variables for {name}; please make sure the environment name is correct")
-
-    return res['environmentByKubernetesNamespaceName']['envVariables']
-
-def get_vars_from_project(client: GqlClient, name: str) -> dict:
-  with client as (_, ds):
-    res = client.execute_query_dynamic(
-        ds.Query.projectByName(name=name).select(
-            ds.Project.envVariables.select(
-                ds.EnvKeyValue.id,
-                ds.EnvKeyValue.name,
-                ds.EnvKeyValue.value,
-                ds.EnvKeyValue.scope,
-            )
-        )
-    )
-    display.v(f"GraphQL query result: {res}")
-    if res['projectByName'] == None:
-      raise AnsibleError(
-          f"Unable to get variables for {name}; please make sure the project name is correct")
-
-    return res['projectByName']['envVariables']
-
-class LookupModule(LookupBase):
+class LookupModule(LagoonLookupBase):
 
   def run(self, terms, variables=None, **kwargs):
 
     ret = []
 
     self.set_options(var_options=variables, direct=kwargs)
-    lagoon = GqlClient(
-        self._templar.template(self.get_option('lagoon_api_endpoint')),
-        self._templar.template(self.get_option('lagoon_api_token')),
-        self.get_option('headers', {})
-    )
+    self.createClient()
     environment = self.get_option('environment')
 
     for term in terms:
       if environment:
         env_name = term + '-' + environment.replace('/', '-').replace('_', '-').replace('.', '-')
-        display.v(f"Lagoon variable lookup environment: {env_name}")
-        env_vars = get_vars_from_environment(lagoon, env_name)
+        self._display.v(f"Lagoon variable lookup environment: {env_name}")
+        lagoonEnvironment = Environment(self.client).byNs(env_name, ['id'])
+        if not len(lagoonEnvironment.environments):
+          raise AnsibleError(
+              f"Unable to fetch environment {env_name}; errors: {lagoonEnvironment.errors}")
+
+        lagoonEnvironment.withVariables()
+        env_vars = lagoonEnvironment.environments[0]['envVariables']
       else:
-        display.v(f"Lagoon variable lookup project: {term}")
-        env_vars = get_vars_from_project(lagoon, term)
+        self._display.v(f"Lagoon variable lookup project: {term}")
+        lagoonProject = Project(self.client).byName(term, ['name'])
+        if not len(lagoonProject.projects):
+          raise AnsibleError(
+              f"Unable to fetch project {term}; errors: {lagoonProject.errors}")
+
+        lagoonProject.withVariables()
+        env_vars = lagoonProject.projects[0]['envVariables']
 
       if self.get_option('return_dict'):
         vars_dict = {}
@@ -147,7 +112,8 @@ class LookupModule(LookupBase):
           vars_dict[var['name']] = var
         ret.append(vars_dict)
       elif self.get_option('var_name'):
-        display.v(f"Lagoon variable lookup name: {self.get_option('var_name')}")
+        self._display.v(
+            f"Lagoon variable lookup name: {self.get_option('var_name')}")
         for var in env_vars:
           if var['name'] == self.get_option('var_name'):
             ret.append(var)

--- a/api/plugins/module_utils/gql.py
+++ b/api/plugins/module_utils/gql.py
@@ -1,4 +1,4 @@
-from ansible.errors import AnsibleError
+from ansible.module_utils.errors import AnsibleValidationError
 from ansible.utils.display import Display
 from gql.transport.requests import RequestsHTTPTransport
 from gql import Client, gql
@@ -14,7 +14,7 @@ class GqlClient:
 
     def __init__(self, endpoint: str, token: str, headers: dict = {}, display: Display = None) -> None:
         if not isinstance(headers, dict):
-            raise AnsibleError("Expecting client headers to be dictionary.")
+            raise AnsibleValidationError("Expecting client headers to be dictionary.")
 
         headers['Content-Type'] = 'application/json'
         headers['Authorization'] = f"Bearer {token}"
@@ -93,6 +93,9 @@ class GqlClient:
             },
         }
         """
+
+        if not len(fields) and not len(subFieldsMap):
+            raise AnsibleValidationError("One of fields or subFieldsMap is required.")
 
         # Build the main query with top-level fields if any.
         queryObj: DSLField = getattr(self.ds.Query, query)

--- a/api/plugins/module_utils/gqlEnvironment.py
+++ b/api/plugins/module_utils/gqlEnvironment.py
@@ -1,4 +1,4 @@
-from ansible_collections.lagoon.api.plugins.module_utils import gqlResourceBase
+from ansible_collections.lagoon.api.plugins.module_utils.gqlResourceBase import CLUSTER_FIELDS, DEFAULT_BATCH_SIZE, DEPLOYMENTS_FIELDS, ENVIRONMENTS_FIELDS, PROJECT_FIELDS, ResourceBase, VARIABLES_FIELDS
 from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
 from ansible_collections.lagoon.api.plugins.module_utils.gqlProject import Project
 from gql.dsl import DSLQuery, dsl_gql
@@ -8,7 +8,7 @@ from typing import List
 from typing_extensions import Self
 
 
-class Environment(gqlResourceBase.ResourceBase):
+class Environment(ResourceBase):
 
     def __init__(self, client: GqlClient, options: dict = {}) -> None:
         super().__init__(client, options)
@@ -23,7 +23,7 @@ class Environment(gqlResourceBase.ResourceBase):
         """
 
         if not fields:
-            fields = gqlResourceBase.ENVIRONMENTS_FIELDS
+            fields = ENVIRONMENTS_FIELDS
 
         joined_fields = "\n        ".join(fields)
 
@@ -52,13 +52,13 @@ class Environment(gqlResourceBase.ResourceBase):
 
         return self
 
-    def allThroughProjects(self, fields: List[str] = None) -> Self:
+    def allThroughProjects(self, fields: List[str] = None, batch_size: int = DEFAULT_BATCH_SIZE) -> Self:
         """
         Get a list of all environments, but going through projects first.
         """
 
         projects = Project(self.client, self.options).all(
-            ).withEnvironments(fields).projects
+            ).withEnvironments(fields, batch_size).projects
 
         for p in projects:
             self.environments.extend(p['environments'])
@@ -71,7 +71,7 @@ class Environment(gqlResourceBase.ResourceBase):
         """
 
         if not fields:
-            fields = gqlResourceBase.ENVIRONMENTS_FIELDS
+            fields = ENVIRONMENTS_FIELDS
 
         joined_fields = "\n        ".join(fields)
 
@@ -105,7 +105,7 @@ class Environment(gqlResourceBase.ResourceBase):
         """
 
         if not fields:
-            fields = gqlResourceBase.ENVIRONMENTS_FIELDS
+            fields = ENVIRONMENTS_FIELDS
 
         joined_fields = "\n        ".join(fields)
 
@@ -132,7 +132,7 @@ class Environment(gqlResourceBase.ResourceBase):
 
         return self
 
-    def withCluster(self, fields: List[str] = None) -> Self:
+    def withCluster(self, fields: List[str] = None, batch_size: int = DEFAULT_BATCH_SIZE) -> Self:
         """
         Retrieve cluster information for the environments.
         """
@@ -143,8 +143,8 @@ class Environment(gqlResourceBase.ResourceBase):
         env_names = [e['kubernetesNamespaceName'] for e in self.environments]
 
         batches = []
-        for i in range(0, len(env_names), self.batch_size):
-            batches.append(env_names[i:i+self.batch_size])
+        for i in range(0, len(env_names), batch_size):
+            batches.append(env_names[i:i+batch_size])
 
         clusters = {}
         for i, b in enumerate(batches):
@@ -158,7 +158,7 @@ class Environment(gqlResourceBase.ResourceBase):
 
         return self
 
-    def withVariables(self, fields: List[str] = None) -> Self:
+    def withVariables(self, fields: List[str] = None, batch_size: int = DEFAULT_BATCH_SIZE) -> Self:
         """
         Retrieve the environments' variables.
         """
@@ -169,8 +169,8 @@ class Environment(gqlResourceBase.ResourceBase):
         env_names = [e['kubernetesNamespaceName'] for e in self.environments]
 
         batches = []
-        for i in range(0, len(env_names), self.batch_size):
-            batches.append(env_names[i:i+self.batch_size])
+        for i in range(0, len(env_names), batch_size):
+            batches.append(env_names[i:i+batch_size])
 
         environmentVars = {}
         for i, b in enumerate(batches):
@@ -184,7 +184,7 @@ class Environment(gqlResourceBase.ResourceBase):
 
         return self
 
-    def withProject(self, fields: List[str] = None) -> Self:
+    def withProject(self, fields: List[str] = None, batch_size: int = DEFAULT_BATCH_SIZE) -> Self:
         """
         Retrieve the environments' project.
         """
@@ -195,8 +195,8 @@ class Environment(gqlResourceBase.ResourceBase):
         env_names = [e['kubernetesNamespaceName'] for e in self.environments]
 
         batches = []
-        for i in range(0, len(env_names), self.batch_size):
-            batches.append(env_names[i:i+self.batch_size])
+        for i in range(0, len(env_names), batch_size):
+            batches.append(env_names[i:i+batch_size])
 
         envProject = {}
         for i, b in enumerate(batches):
@@ -210,7 +210,7 @@ class Environment(gqlResourceBase.ResourceBase):
 
         return self
 
-    def withDeployments(self, fields: List[str] = None) -> Self:
+    def withDeployments(self, fields: List[str] = None, batch_size: int = DEFAULT_BATCH_SIZE) -> Self:
         """
         Retrieve the environments' deployments.
         """
@@ -221,8 +221,8 @@ class Environment(gqlResourceBase.ResourceBase):
         env_names = [e['kubernetesNamespaceName'] for e in self.environments]
 
         batches = []
-        for i in range(0, len(env_names), self.batch_size):
-            batches.append(env_names[i:i+self.batch_size])
+        for i in range(0, len(env_names), batch_size):
+            batches.append(env_names[i:i+batch_size])
 
         envDeployments = {}
         for i, b in enumerate(batches):
@@ -240,7 +240,7 @@ class Environment(gqlResourceBase.ResourceBase):
         res = {}
 
         if not fields or not len(fields):
-            fields = gqlResourceBase.CLUSTER_FIELDS
+            fields = CLUSTER_FIELDS
 
         clusters = {}
         with self.client as (_, ds):
@@ -287,7 +287,7 @@ class Environment(gqlResourceBase.ResourceBase):
         res = {}
 
         if not fields or not len(fields):
-            fields = gqlResourceBase.VARIABLES_FIELDS
+            fields = VARIABLES_FIELDS
 
         variables = {}
         with self.client as (_, ds):
@@ -334,7 +334,7 @@ class Environment(gqlResourceBase.ResourceBase):
         res = {}
 
         if not fields or not len(fields):
-            fields = gqlResourceBase.PROJECT_FIELDS
+            fields = PROJECT_FIELDS
 
         projects = {}
         with self.client as (_, ds):
@@ -381,7 +381,7 @@ class Environment(gqlResourceBase.ResourceBase):
         res = {}
 
         if not fields or not len(fields):
-            fields = gqlResourceBase.DEPLOYMENTS_FIELDS
+            fields = DEPLOYMENTS_FIELDS
 
         deployments = {}
         with self.client as (_, ds):

--- a/api/plugins/module_utils/gqlProject.py
+++ b/api/plugins/module_utils/gqlProject.py
@@ -1,8 +1,9 @@
-from ansible_collections.lagoon.api.plugins.module_utils.gqlResourceBase import CLUSTER_FIELDS, ENVIRONMENTS_FIELDS, PROJECT_FIELDS, ResourceBase, VARIABLES_FIELDS
+from ansible_collections.lagoon.api.plugins.module_utils.gqlResourceBase import CLUSTER_FIELDS, DEFAULT_BATCH_SIZE, ENVIRONMENTS_FIELDS, PROJECT_FIELDS, ResourceBase, VARIABLES_FIELDS
 from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
 from gql.dsl import DSLQuery, dsl_gql
 from gql.transport.exceptions import TransportQueryError
 from graphql import print_ast
+from typing import List
 from typing_extensions import Self
 
 PROJECT_DEPLOY_TARGET_CONFIGS_FIELDS = [
@@ -26,7 +27,7 @@ class Project(ResourceBase):
         super().__init__(client, options)
         self.projects = []
 
-    def all(self, fields: list[str] = None) -> Self:
+    def all(self, fields: List[str] = None) -> Self:
         """
         Get a list of all projects, but only top level fields.
 
@@ -40,7 +41,7 @@ class Project(ResourceBase):
         return self.queryTopLevelFields(
             self.projects, 'allProjects', 'Project', fields=fields)
 
-    def allInGroup(self, group: str, fields: list[str] = None) -> Self:
+    def allInGroup(self, group: str, fields: List[str] = None) -> Self:
         """
         Get a list of all projects in a group.
         """
@@ -52,7 +53,7 @@ class Project(ResourceBase):
         return self.queryTopLevelFields(
             self.projects, 'allProjectsInGroup', 'Project', args, fields)
 
-    def byName(self, name: str, fields: list[str] = None) -> Self:
+    def byName(self, name: str, fields: List[str] = None) -> Self:
         """
         Get the top-level information for a project.
         """
@@ -64,7 +65,7 @@ class Project(ResourceBase):
         return self.queryTopLevelFields(
             self.projects, 'projectByName', 'Project', args, fields)
 
-    def withCluster(self, fields: list[str] = None) -> Self:
+    def withCluster(self, fields: List[str] = None, batch_size: int = DEFAULT_BATCH_SIZE) -> Self:
         """
         Retrieve cluster information for the projects.
         """
@@ -75,8 +76,8 @@ class Project(ResourceBase):
         project_names = [p['name'] for p in self.projects]
 
         batches = []
-        for i in range(0, len(project_names), self.batch_size):
-            batches.append(project_names[i:i+self.batch_size])
+        for i in range(0, len(project_names), batch_size):
+            batches.append(project_names[i:i+batch_size])
 
         clusters = {}
         for i, b in enumerate(batches):
@@ -89,7 +90,7 @@ class Project(ResourceBase):
 
         return self
 
-    def withEnvironments(self, fields: list[str] = None) -> Self:
+    def withEnvironments(self, fields: List[str] = None, batch_size: int = DEFAULT_BATCH_SIZE) -> Self:
         """
         Retrieve the projects' environments.
         """
@@ -100,8 +101,8 @@ class Project(ResourceBase):
         project_names = [p['name'] for p in self.projects]
 
         batches = []
-        for i in range(0, len(project_names), self.batch_size):
-            batches.append(project_names[i:i+self.batch_size])
+        for i in range(0, len(project_names), batch_size):
+            batches.append(project_names[i:i+batch_size])
 
         environments = {}
         for i, b in enumerate(batches):
@@ -113,7 +114,7 @@ class Project(ResourceBase):
 
         return self
 
-    def withDeployTargetConfigs(self, fields: list[str] = None) -> Self:
+    def withDeployTargetConfigs(self, fields: List[str] = None, batch_size: int = DEFAULT_BATCH_SIZE) -> Self:
         """
         Retrieve the projects' deploy target configs.
         """
@@ -124,8 +125,8 @@ class Project(ResourceBase):
         project_names = [p['name'] for p in self.projects]
 
         batches = []
-        for i in range(0, len(project_names), self.batch_size):
-            batches.append(project_names[i:i+self.batch_size])
+        for i in range(0, len(project_names), batch_size):
+            batches.append(project_names[i:i+batch_size])
 
         dtcs = {}
         for i, b in enumerate(batches):
@@ -137,7 +138,7 @@ class Project(ResourceBase):
 
         return self
 
-    def withVariables(self, fields: list[str] = None) -> Self:
+    def withVariables(self, fields: List[str] = None, batch_size: int = DEFAULT_BATCH_SIZE) -> Self:
         """
         Retrieve the projects' variables.
         """
@@ -148,8 +149,8 @@ class Project(ResourceBase):
         project_names = [p['name'] for p in self.projects]
 
         batches = []
-        for i in range(0, len(project_names), self.batch_size):
-            batches.append(project_names[i:i+self.batch_size])
+        for i in range(0, len(project_names), batch_size):
+            batches.append(project_names[i:i+batch_size])
 
         projectVars = {}
         for i, b in enumerate(batches):
@@ -161,7 +162,7 @@ class Project(ResourceBase):
 
         return self
 
-    def withGroups(self, fields: list[str] = None) -> Self:
+    def withGroups(self, fields: List[str] = None, batch_size: int = DEFAULT_BATCH_SIZE) -> Self:
         """
         Retrieve the projects' groups.
         """
@@ -172,8 +173,8 @@ class Project(ResourceBase):
         project_names = [p['name'] for p in self.projects]
 
         batches = []
-        for i in range(0, len(project_names), self.batch_size):
-            batches.append(project_names[i:i+self.batch_size])
+        for i in range(0, len(project_names), batch_size):
+            batches.append(project_names[i:i+batch_size])
 
         groups = {}
         for i, b in enumerate(batches):
@@ -185,7 +186,7 @@ class Project(ResourceBase):
 
         return self
 
-    def getCluster(self, project_names: list[str], fields: list[str] = None) -> list[dict]:
+    def getCluster(self, project_names: List[str], fields: List[str] = None) -> List[dict]:
         res = {}
 
         if not fields or not len(fields):
@@ -231,7 +232,7 @@ class Project(ResourceBase):
 
         return res
 
-    def getEnvironments(self, project_names: list[str], fields: list[str] = None) -> list[dict]:
+    def getEnvironments(self, project_names: List[str], fields: List[str] = None) -> List[dict]:
         res = {}
 
         if not fields or not len(fields):
@@ -277,7 +278,7 @@ class Project(ResourceBase):
 
         return res
 
-    def getDeployTargetConfigs(self, project_names: list[str], fields: list[str] = None) -> list[dict]:
+    def getDeployTargetConfigs(self, project_names: List[str], fields: List[str] = None) -> List[dict]:
         res = {}
 
         if not fields or not len(fields):
@@ -331,7 +332,7 @@ class Project(ResourceBase):
 
         return res
 
-    def getVariables(self, project_names: list[str], fields: list[str] = None) -> list[dict]:
+    def getVariables(self, project_names: List[str], fields: List[str] = None) -> List[dict]:
         res = {}
 
         if not fields or not len(fields):
@@ -377,7 +378,7 @@ class Project(ResourceBase):
 
         return res
 
-    def getGroups(self, project_names: list[str], fields: list[str] = None) -> list[dict]:
+    def getGroups(self, project_names: List[str], fields: List[str] = None) -> List[dict]:
         res = {}
 
         if not fields or not len(fields):

--- a/api/plugins/module_utils/gqlResourceBase.py
+++ b/api/plugins/module_utils/gqlResourceBase.py
@@ -79,6 +79,9 @@ class ResourceBase:
         self.display = display
         self.options = options
 
+    def sanitisedName(self, name):
+        return re.sub(r'[\W_-]+', '-', name)
+
     def sanitiseForQueryAlias(self, name):
         return re.sub(r'[\W-]+', '_', name)
 

--- a/api/plugins/module_utils/gqlResourceBase.py
+++ b/api/plugins/module_utils/gqlResourceBase.py
@@ -2,6 +2,7 @@ import re
 from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
 from ansible.utils.display import Display
 from gql.transport.exceptions import TransportQueryError
+from typing import Dict, List
 from typing_extensions import Self
 
 display = Display()
@@ -67,6 +68,8 @@ DEPLOYMENTS_FIELDS = [
     'uiLink',
 ]
 
+DEFAULT_BATCH_SIZE = 100
+
 
 class ResourceBase:
 
@@ -74,14 +77,12 @@ class ResourceBase:
         self.client = client
         self.errors = []
         self.display = display
-
         self.options = options
-        self.batch_size = options.get('batch_size', 100)
 
     def sanitiseForQueryAlias(self, name):
         return re.sub(r'[\W-]+', '_', name)
 
-    def queryTopLevelFields(self, resList: list, query: str, qryType: str, args: dict[str, any] = {}, fields: list[str] = []) -> Self:
+    def queryTopLevelFields(self, resList: list, query: str, qryType: str, args: Dict[str, any] = {}, fields: List[str] = []) -> Self:
         with self.client:
             queryObj = self.client.build_dynamic_query(query, qryType, args, fields)
             try:

--- a/api/plugins/module_utils/gqlResourceBase.py
+++ b/api/plugins/module_utils/gqlResourceBase.py
@@ -1,7 +1,8 @@
 import re
-
 from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
 from ansible.utils.display import Display
+from gql.transport.exceptions import TransportQueryError
+from typing_extensions import Self
 
 display = Display()
 
@@ -66,6 +67,7 @@ DEPLOYMENTS_FIELDS = [
     'uiLink',
 ]
 
+
 class ResourceBase:
 
     def __init__(self, client: GqlClient, options: dict = {}) -> None:
@@ -78,3 +80,26 @@ class ResourceBase:
 
     def sanitiseForQueryAlias(self, name):
         return re.sub(r'[\W-]+', '_', name)
+
+    def queryTopLevelFields(self, resList: list, query: str, qryType: str, args: dict[str, any] = {}, fields: list[str] = []) -> Self:
+        with self.client:
+            queryObj = self.client.build_dynamic_query(query, qryType, args, fields)
+            try:
+                res = self.client.execute_query_dynamic(queryObj)
+                if isinstance(res[query], list):
+                    resList.extend(res[query])
+                elif isinstance(res[query], dict):
+                    resList.append(res[query])
+            except TransportQueryError as e:
+                if isinstance(e.data[query], list):
+                    resList.extend(e.data[query])
+                    self.errors.extend(e.errors)
+                elif isinstance(e.data[query], dict):
+                    resList.append(e.data[query])
+                    self.errors.extend(e.errors)
+                else:
+                    raise
+            except Exception:
+                raise
+
+            return self

--- a/api/tests/common/__init__.py
+++ b/api/tests/common/__init__.py
@@ -1,0 +1,15 @@
+from os.path import dirname, realpath
+from gql.dsl import dsl_gql, DSLField, DSLQuery, print_ast
+from graphql import GraphQLSchema, build_ast_schema, parse
+
+script_dir = dirname(realpath(__file__))
+
+def load_schema() -> GraphQLSchema:
+    with open(f'{script_dir}/schema.graphql') as f:
+        schema_str = f.read()
+        type_def_ast = parse(schema_str)
+        schema = build_ast_schema(type_def_ast)
+        return schema
+
+def dsl_field_query_to_str(query: DSLField) -> str:
+    return print_ast(dsl_gql(DSLQuery(query)))

--- a/api/tests/common/schema.graphql
+++ b/api/tests/common/schema.graphql
@@ -1,0 +1,3967 @@
+""""""
+type Query {
+  """Returns the current user"""
+  me: User
+
+  """Returns User Object by a given sshKey"""
+  userBySshKey(sshKey: String!): User
+
+  """Returns Project Object by a given name"""
+  projectByName(name: String!): Project
+
+  """Returns Group Object by a given name"""
+  groupByName(name: String!): GroupInterface
+
+  """
+  Returns Project Object by a given gitUrl (only the first one if there are multiple)
+  """
+  projectByGitUrl(gitUrl: String!): Project
+
+  """"""
+  environmentByName(name: String!, project: Int!, includeDeleted: Boolean): Environment
+
+  """"""
+  environmentById(id: Int!): Environment
+
+  """Returns Environment Object by a given openshiftProjectName"""
+  environmentByOpenshiftProjectName(openshiftProjectName: String!): Environment
+
+  """Returns Environment Object by a given kubernetesNamespaceName"""
+  environmentByKubernetesNamespaceName(kubernetesNamespaceName: String!): Environment
+
+  """Return projects from a fact-based search"""
+  projectsByFactSearch(input: FactFilterInput): ProjectFactSearchResults
+
+  """Return environments from a fact-based search"""
+  environmentsByFactSearch(input: FactFilterInput): EnvironmentFactSearchResults
+
+  """"""
+  userCanSshToEnvironment(openshiftProjectName: String, kubernetesNamespaceName: String): Environment
+
+  """"""
+  deploymentByRemoteId(id: String): Deployment
+
+  """"""
+  deploymentsByBulkId(bulkId: String): [Deployment]
+
+  """"""
+  deploymentsByFilter(openshifts: [Int], deploymentStatus: [DeploymentStatusType]): [Deployment]
+
+  """"""
+  taskByTaskName(taskName: String): Task
+
+  """"""
+  taskByRemoteId(id: String): Task
+
+  """"""
+  taskById(id: Int): Task
+
+  """
+  Returns all Project Objects matching given filters (all if no filter defined)
+  """
+  allProjects(createdAfter: String, gitUrl: String, order: ProjectOrderType): [Project]
+
+  """Returns all Project Objects matching metadata filters"""
+  projectsByMetadata(metadata: [MetadataKeyValue]): [Project]
+
+  """Returns all OpenShift Objects"""
+  allOpenshifts: [Openshift]
+
+  """Returns all Kubernetes Objects"""
+  allKubernetes: [Kubernetes]
+
+  """
+  Returns all Environments matching given filter (all if no filter defined)
+  """
+  allEnvironments(createdAfter: String, type: EnvType, order: EnvOrderType): [Environment]
+
+  """Returns all Problems matching given filter (all if no filter defined)"""
+  allProblems(source: [String], project: Int, environment: Int, envType: [EnvType], identifier: String, severity: [ProblemSeverityRating]): [Problem]
+
+  """"""
+  problemSources: [String]
+
+  """Returns all Groups matching given filter (all if no filter defined)"""
+  allGroups(name: String, type: String): [GroupInterface]
+
+  """Returns all projects in a given group"""
+  allProjectsInGroup(input: GroupInput): [Project]
+
+  """Returns LAGOON_VERSION"""
+  lagoonVersion: JSON
+
+  """Returns all ProblemHarborScanMatchers"""
+  allProblemHarborScanMatchers: [ProblemHarborScanMatch]
+
+  """Returns all AdvancedTaskDefinitions"""
+  allAdvancedTaskDefinitions: [AdvancedTaskDefinition]
+
+  """Returns a single AdvancedTaskDefinition given an id"""
+  advancedTaskDefinitionById(id: Int!): AdvancedTaskDefinition
+
+  """Returns a AdvancedTaskDefinitions applicable for an environment"""
+  advancedTasksForEnvironment(environment: Int!): [AdvancedTaskDefinition]
+
+  """Returns a AdvancedTaskDefinitionArgument by Id"""
+  advancedTaskDefinitionArgumentById(id: Int!): [AdvancedTaskDefinitionArgument]
+
+  """Returns all Workflows for an environment"""
+  workflowsForEnvironment(environment: Int!): [Workflow]
+
+  """Returns the DeployTargetConfig by a deployTargetConfig Id"""
+  deployTargetConfigById(id: Int!): DeployTargetConfig @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+
+  """Returns all DeployTargetConfig by a project Id"""
+  deployTargetConfigsByProjectId(project: Int!): [DeployTargetConfig] @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+
+  """
+  Returns all DeployTargetConfig by a deployTarget Id (aka: Openshift Id)
+  """
+  deployTargetConfigsByDeployTarget(deployTarget: Int!): [DeployTargetConfig] @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+
+  """"""
+  allDeployTargetConfigs: [DeployTargetConfig] @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+}
+
+""""""
+type User {
+  """"""
+  id: String
+
+  """"""
+  email: String
+
+  """"""
+  firstName: String
+
+  """"""
+  lastName: String
+
+  """"""
+  comment: String
+
+  """"""
+  gitlabId: Int
+
+  """"""
+  sshKeys: [SshKey]
+
+  """"""
+  groups: [GroupInterface]
+}
+
+""""""
+type SshKey {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  keyValue: String
+
+  """"""
+  keyType: String
+
+  """"""
+  keyFingerprint: String
+
+  """"""
+  created: String
+}
+
+""""""
+interface GroupInterface {
+  """"""
+  id: String
+
+  """"""
+  name: String
+
+  """"""
+  type: String
+
+  """"""
+  groups: [GroupInterface]
+
+  """"""
+  members: [GroupMembership]
+
+  """"""
+  projects: [Project]
+}
+
+""""""
+type GroupMembership {
+  """"""
+  user: User
+
+  """"""
+  role: GroupRole
+}
+
+""""""
+enum GroupRole {
+  """"""
+  GUEST
+
+  """"""
+  REPORTER
+
+  """"""
+  DEVELOPER
+
+  """"""
+  MAINTAINER
+
+  """"""
+  OWNER
+}
+
+"""Lagoon Project (like a git repository)"""
+type Project {
+  """ID of project"""
+  id: Int
+
+  """Name of project"""
+  name: String
+
+  """
+  Git URL, needs to be SSH Git URL in one of these two formats
+  - git@172.17.0.1/project1.git
+  - ssh://git@172.17.0.1:2222/project1.git
+  """
+  gitUrl: String
+
+  """Project Availability STANDARD|HIGH"""
+  availability: ProjectAvailability
+
+  """
+      SSH Private Key for Project
+      Will be used to authenticate against the Git Repo of the Project
+      Needs to be in single string separated by `
+  `, example:
+      ```
+      -----BEGIN RSA PRIVATE KEY-----
+  MIIJKQIBAAKCAgEA+o[...]P0yoL8BoQQG2jCvYfWh6vyglQdrDYx/o6/8ecTwXokKKh6fg1q
+  -----END RSA PRIVATE KEY-----
+      ```
+  """
+  privateKey: String
+
+  """
+  Set if the .lagoon.yml should be found in a subfolder
+  Usefull if you have multiple Lagoon projects per Git Repository
+  """
+  subfolder: String
+
+  """
+  Set if the project should use a routerPattern that is different from the deploy target default
+  """
+  routerPattern: String
+
+  """Notifications that should be sent for this project"""
+  notifications(type: NotificationType, contentType: NotificationContentType, notificationSeverityThreshold: ProblemSeverityRating): [Notification]
+
+  """
+  Which internal Lagoon System is responsible for deploying
+  Currently only 'lagoon_controllerBuildDeploy' exists
+  """
+  activeSystemsDeploy: String
+
+  """
+  Which internal Lagoon System is responsible for promoting
+  Currently only 'lagoon_controllerBuildDeploy' exists
+  """
+  activeSystemsPromote: String
+
+  """
+  Which internal Lagoon System is responsible for promoting
+  Currently only 'lagoon_controllerRemove' exists
+  """
+  activeSystemsRemove: String
+
+  """
+  Which internal Lagoon System is responsible for tasks
+  Currently only 'lagoon_controllerJob' exists
+  """
+  activeSystemsTask: String
+
+  """
+  Which internal Lagoon System is responsible for miscellaneous tasks
+  Currently only 'lagoon_controllerMisc' exists
+  """
+  activeSystemsMisc: String
+
+  """
+  Which branches should be deployed, can be one of:
+  - `true` - all branches are deployed
+  - `false` - no branches are deployed
+  - REGEX - regex of all branches that should be deployed, example: `^(main|staging)$`
+  """
+  branches: String
+
+  """
+  Which Pull Requests should be deployed, can be one of:
+  - `true` - all pull requests are deployed
+  - `false` - no pull requests are deployed
+  - REGEX - regex of all Pull Request titles that should be deployed, example: `[BUILD]`
+  """
+  pullrequests: String
+
+  """
+  Which environment(the name) should be marked as the production environment.
+  *Important:* If you change this, you need to deploy both environments (the current and previous one) that are affected in order for the change to propagate correctly
+  """
+  productionEnvironment: String
+
+  """Routes that are attached to the active environment"""
+  productionRoutes: String
+
+  """
+  The drush alias to use for the active production environment
+  *Important:* This is mainly used for drupal, but could be used for other services potentially
+  """
+  productionAlias: String
+
+  """
+  Which environment(the name) should be marked as the production standby environment.
+  *Important:* This is used to determine which environment should be marked as the standby production environment
+  """
+  standbyProductionEnvironment: String
+
+  """Routes that are attached to the standby environment"""
+  standbyRoutes: String
+
+  """
+  The drush alias to use for the standby production environment
+  *Important:* This is mainly used for drupal, but could be used for other services potentially
+  """
+  standbyAlias: String
+
+  """
+  What the production environment build priority should be (`0 through 10`)
+  """
+  productionBuildPriority: Int
+
+  """
+  What the development environment build priority should be (`0 through 10`)
+  """
+  developmentBuildPriority: Int
+
+  """Should this project have auto idling enabled (`1` or `0`)"""
+  autoIdle: Int
+
+  """Should storage for this environment be calculated (`1` or `0`)"""
+  storageCalc: Int
+
+  """Should the Problems UI be available for this Project (`1` or `0`)"""
+  problemsUi: Int
+
+  """Should the Facts UI be available for this Project (`1` or `0`)"""
+  factsUi: Int
+
+  """
+  Should the ability to deploy environments be disabled for this Project (`1` or `0`)
+  """
+  deploymentsDisabled: Int
+
+  """Reference to OpenShift Object this Project should be deployed to"""
+  openshift: Openshift
+
+  """
+  Pattern of OpenShift Project/Namespace that should be generated, default: `${project}-${environmentname}`
+  """
+  openshiftProjectPattern: String
+
+  """Reference to Kubernetes Object this Project should be deployed to"""
+  kubernetes: Kubernetes
+
+  """
+  Pattern of Kubernetes Namespace that should be generated, default: `${project}-${environmentname}`
+  """
+  kubernetesNamespacePattern: String
+
+  """How many environments can be deployed at one timeout"""
+  developmentEnvironmentsLimit: Int
+
+  """Name of the OpenShift Project/Namespace"""
+  openshiftProjectName: String
+
+  """Deployed Environments for this Project"""
+  environments(
+    """Filter by Environment Type"""
+    type: EnvType
+
+    """
+    Include deleted Environments (by default deleted environment are hidden)
+    """
+    includeDeleted: Boolean
+
+    """Filter environments by fact matching"""
+    factFilter: FactFilterInput
+  ): [Environment]
+
+  """Creation Timestamp of Project"""
+  created: String
+
+  """Environment variables available during build-time and run-time"""
+  envVariables: [EnvKeyValue]
+
+  """Which groups are directly linked to project"""
+  groups: [GroupInterface]
+
+  """Metadata key/values stored against a project"""
+  metadata: JSON
+
+  """
+  DeployTargetConfigs are a way to define which deploy targets are used for a project
+  """
+  deployTargetConfigs: [DeployTargetConfig] @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+}
+
+""""""
+enum ProjectAvailability {
+  """"""
+  STANDARD
+
+  """"""
+  HIGH
+
+  """"""
+  POLYSITE
+}
+
+""""""
+enum NotificationType {
+  """"""
+  SLACK
+
+  """"""
+  ROCKETCHAT
+
+  """"""
+  MICROSOFTTEAMS
+
+  """"""
+  EMAIL
+
+  """"""
+  WEBHOOK
+}
+
+""""""
+enum NotificationContentType {
+  """"""
+  DEPLOYMENT
+
+  """"""
+  PROBLEM
+}
+
+""""""
+enum ProblemSeverityRating {
+  """"""
+  NONE
+
+  """"""
+  UNKNOWN
+
+  """"""
+  NEGLIGIBLE
+
+  """"""
+  LOW
+
+  """"""
+  MEDIUM
+
+  """"""
+  HIGH
+
+  """"""
+  CRITICAL
+}
+
+""""""
+union Notification = NotificationRocketChat | NotificationSlack | NotificationMicrosoftTeams | NotificationEmail | NotificationWebhook
+
+""""""
+type NotificationRocketChat {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  webhook: String
+
+  """"""
+  channel: String
+
+  """"""
+  contentType: String
+
+  """"""
+  notificationSeverityThreshold: ProblemSeverityRating
+}
+
+""""""
+type NotificationSlack {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  webhook: String
+
+  """"""
+  channel: String
+
+  """"""
+  contentType: String
+
+  """"""
+  notificationSeverityThreshold: ProblemSeverityRating
+}
+
+""""""
+type NotificationMicrosoftTeams {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  webhook: String
+
+  """"""
+  contentType: String
+
+  """"""
+  notificationSeverityThreshold: ProblemSeverityRating
+}
+
+""""""
+type NotificationEmail {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  emailAddress: String
+
+  """"""
+  contentType: String
+
+  """"""
+  notificationSeverityThreshold: ProblemSeverityRating
+}
+
+""""""
+type NotificationWebhook {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  webhook: String
+
+  """"""
+  contentType: String
+
+  """"""
+  notificationSeverityThreshold: ProblemSeverityRating
+}
+
+""""""
+type Openshift {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  consoleUrl: String
+
+  """"""
+  token: String
+
+  """"""
+  routerPattern: String
+
+  """"""
+  projectUser: String @deprecated(reason: "Not used with RBAC permissions")
+
+  """"""
+  sshHost: String
+
+  """"""
+  sshPort: String
+
+  """"""
+  created: String
+
+  """"""
+  monitoringConfig: JSON
+
+  """"""
+  friendlyName: String
+
+  """"""
+  cloudProvider: String
+
+  """"""
+  cloudRegion: String
+
+  """"""
+  buildImage: String
+}
+
+""""""
+scalar JSON
+
+""""""
+type Kubernetes {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  consoleUrl: String
+
+  """"""
+  token: String
+
+  """"""
+  routerPattern: String
+
+  """"""
+  projectUser: String @deprecated(reason: "Not used with RBAC permissions")
+
+  """"""
+  sshHost: String
+
+  """"""
+  sshPort: String
+
+  """"""
+  created: String
+
+  """"""
+  monitoringConfig: JSON
+
+  """"""
+  friendlyName: String
+
+  """"""
+  cloudProvider: String
+
+  """"""
+  cloudRegion: String
+
+  """"""
+  buildImage: String
+}
+
+""""""
+enum EnvType {
+  """"""
+  PRODUCTION
+
+  """"""
+  DEVELOPMENT
+}
+
+""""""
+input FactFilterInput {
+  """"""
+  filterConnective: FactFilterConnective
+
+  """"""
+  filters: [FactFilterAtom]
+
+  """"""
+  skip: Int
+
+  """"""
+  take: Int
+
+  """"""
+  orderBy: String
+}
+
+""""""
+enum FactFilterConnective {
+  """"""
+  OR
+
+  """"""
+  AND
+}
+
+""""""
+input FactFilterAtom {
+  """"""
+  lhsTarget: FactFilterLHSTarget
+
+  """"""
+  name: String!
+
+  """"""
+  contains: String!
+}
+
+""""""
+enum FactFilterLHSTarget {
+  """"""
+  FACT
+
+  """"""
+  ENVIRONMENT
+
+  """"""
+  PROJECT
+}
+
+"""
+Lagoon Environment (for each branch, pullrequest there is an individual environment)
+"""
+type Environment {
+  """Internal ID of this Environment"""
+  id: Int
+
+  """Name of this Environment"""
+  name: String
+
+  """Reference to the Project Object"""
+  project: Project
+
+  """
+  Which Deployment Type this environment is, can be `branch`, `pullrequest`, `promote`
+  """
+  deployType: String
+
+  """
+  The version control base ref for deployments (e.g., branch name, tag, or commit id)
+  """
+  deployBaseRef: String
+
+  """
+  The version control head ref for deployments (e.g., branch name, tag, or commit id)
+  """
+  deployHeadRef: String
+
+  """The title of the last deployment (PR title)"""
+  deployTitle: String
+
+  """Should this environment have auto idling enabled (`1` or `0`)"""
+  autoIdle: Int
+
+  """
+  Which Environment Type this environment is, can be `production`, `development`
+  """
+  environmentType: String
+
+  """
+  Name of the OpenShift Project/Namespace this environment is deployed into
+  """
+  openshiftProjectName: String
+
+  """Name of the Kubernetes Namespace this environment is deployed into"""
+  kubernetesNamespaceName: String
+
+  """Unix Timestamp of the last time this environment has been updated"""
+  updated: String
+
+  """Unix Timestamp if the creation time"""
+  created: String
+
+  """Unix Timestamp of when this project has been deleted"""
+  deleted: String
+
+  """
+  Reference to EnvironmentHoursMonth API Object, which returns how many hours this environment ran in a specific month
+  """
+  hoursMonth(month: Date): EnvironmentHoursMonth
+
+  """
+  Reference to EnvironmentStorage API Object, which shows the Storage consumption of this environment per day
+  """
+  storages: [EnvironmentStorage]
+
+  """
+  Reference to EnvironmentStorageMonth API Object, which returns how many storage per day this environment used in a specific month
+  """
+  storageMonth(month: Date): EnvironmentStorageMonth
+
+  """
+  Reference to EnvironmentHitsMonth API Object, which returns how many hits this environment generated in a specific month
+  """
+  hitsMonth(month: Date): EnvironmentHitsMonth
+
+  """Environment variables available during build-time and run-time"""
+  envVariables: [EnvKeyValue]
+
+  """"""
+  route: String
+
+  """"""
+  routes: String
+
+  """"""
+  monitoringUrls: String
+
+  """"""
+  deployments(name: String, limit: Int): [Deployment]
+
+  """"""
+  insights(type: String, limit: Int): [Insight]
+
+  """"""
+  backups(includeDeleted: Boolean, limit: Int): [Backup]
+
+  """"""
+  tasks(id: Int, taskName: String, limit: Int): [Task]
+
+  """"""
+  advancedTasks: [AdvancedTaskDefinition]
+
+  """"""
+  services: [EnvironmentService]
+
+  """"""
+  problems(severity: [ProblemSeverityRating], source: [String]): [Problem]
+
+  """"""
+  facts(keyFacts: Boolean, limit: Int, summary: Boolean): [Fact]
+
+  """"""
+  openshift: Openshift
+
+  """"""
+  openshiftProjectPattern: String
+
+  """"""
+  kubernetes: Kubernetes
+
+  """"""
+  kubernetesNamespacePattern: String
+
+  """"""
+  workflows: [Workflow]
+}
+
+""""""
+scalar Date
+
+""""""
+type EnvironmentHoursMonth {
+  """"""
+  month: String
+
+  """"""
+  hours: Int
+}
+
+""""""
+type EnvironmentStorage {
+  """"""
+  id: Int
+
+  """"""
+  environment: Environment
+
+  """"""
+  persistentStorageClaim: String
+
+  """"""
+  bytesUsed: Float
+
+  """"""
+  updated: String
+}
+
+""""""
+type EnvironmentStorageMonth {
+  """"""
+  month: String
+
+  """"""
+  bytesUsed: Float
+}
+
+""""""
+type EnvironmentHitsMonth {
+  """"""
+  total: Int
+}
+
+""""""
+type EnvKeyValue {
+  """"""
+  id: Int
+
+  """"""
+  scope: String
+
+  """"""
+  name: String
+
+  """"""
+  value: String
+}
+
+""""""
+type Deployment {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  status: String
+
+  """"""
+  created: String
+
+  """"""
+  started: String
+
+  """"""
+  completed: String
+
+  """"""
+  environment: Environment
+
+  """"""
+  remoteId: String
+
+  """"""
+  buildLog: String
+
+  """The Lagoon URL"""
+  uiLink: String
+
+  """"""
+  priority: Int
+
+  """"""
+  bulkId: String
+
+  """"""
+  bulkName: String
+}
+
+""""""
+type Insight {
+  """"""
+  id: Int
+
+  """"""
+  type: String
+
+  """"""
+  service: String
+
+  """"""
+  created: String
+
+  """"""
+  fileId: String
+
+  """"""
+  data: String
+
+  """"""
+  file: String!
+
+  """"""
+  size: String
+
+  """"""
+  environment: Environment!
+
+  """"""
+  downloadUrl: String
+}
+
+""""""
+type Backup {
+  """"""
+  id: Int
+
+  """"""
+  environment: Environment
+
+  """"""
+  source: String
+
+  """"""
+  backupId: String
+
+  """"""
+  created: String
+
+  """"""
+  deleted: String
+
+  """"""
+  restore: Restore
+}
+
+""""""
+type Restore {
+  """"""
+  id: Int
+
+  """"""
+  backupId: String
+
+  """"""
+  status: String
+
+  """"""
+  restoreLocation: String
+
+  """"""
+  created: String
+}
+
+""""""
+type Task {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  taskName: String
+
+  """"""
+  status: String
+
+  """"""
+  created: String
+
+  """"""
+  started: String
+
+  """"""
+  completed: String
+
+  """"""
+  environment: Environment
+
+  """"""
+  service: String
+
+  """"""
+  command: String
+
+  """"""
+  remoteId: String
+
+  """"""
+  logs: String
+
+  """"""
+  files: [File]
+}
+
+""""""
+type File {
+  """"""
+  id: Int
+
+  """"""
+  filename: String
+
+  """"""
+  download: String
+
+  """"""
+  created: String
+}
+
+""""""
+union AdvancedTaskDefinition = AdvancedTaskDefinitionImage | AdvancedTaskDefinitionCommand
+
+""""""
+type AdvancedTaskDefinitionImage {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  description: String
+
+  """"""
+  confirmationText: String
+
+  """"""
+  type: AdvancedTaskDefinitionTypes
+
+  """"""
+  image: String
+
+  """"""
+  service: String
+
+  """"""
+  groupName: String
+
+  """"""
+  environment: Int
+
+  """"""
+  project: Int
+
+  """"""
+  permission: TaskPermission
+
+  """"""
+  advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgument]
+
+  """"""
+  created: String
+
+  """"""
+  deleted: String
+}
+
+""""""
+enum AdvancedTaskDefinitionTypes {
+  """"""
+  COMMAND
+
+  """"""
+  IMAGE
+}
+
+""""""
+enum TaskPermission {
+  """"""
+  MAINTAINER
+
+  """"""
+  DEVELOPER
+
+  """"""
+  GUEST
+}
+
+""""""
+type AdvancedTaskDefinitionArgument {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  displayName: String
+
+  """"""
+  type: String
+
+  """"""
+  range: [String]
+
+  """"""
+  advancedTaskDefinition: AdvancedTaskDefinition
+}
+
+""""""
+type AdvancedTaskDefinitionCommand {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  description: String
+
+  """"""
+  confirmationText: String
+
+  """"""
+  type: AdvancedTaskDefinitionTypes
+
+  """"""
+  service: String
+
+  """"""
+  command: String
+
+  """"""
+  groupName: String
+
+  """"""
+  environment: Int
+
+  """"""
+  project: Int
+
+  """"""
+  permission: TaskPermission
+
+  """"""
+  advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgument]
+
+  """"""
+  created: String
+
+  """"""
+  deleted: String
+}
+
+""""""
+type EnvironmentService {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+}
+
+""""""
+type Problem {
+  """"""
+  id: Int
+
+  """"""
+  environment: Environment
+
+  """"""
+  severity: ProblemSeverityRating
+
+  """"""
+  severityScore: SeverityScore
+
+  """"""
+  identifier: String
+
+  """"""
+  service: String
+
+  """"""
+  source: String
+
+  """"""
+  associatedPackage: String
+
+  """"""
+  description: String
+
+  """"""
+  links: String
+
+  """"""
+  version: String
+
+  """"""
+  fixedVersion: String
+
+  """"""
+  data: String
+
+  """"""
+  created: String
+
+  """"""
+  deleted: String
+}
+
+"""Severity score is a numeric measure (0-1) of a problems severity"""
+scalar SeverityScore
+
+""""""
+type Fact {
+  """"""
+  id: Int
+
+  """"""
+  environment: Environment
+
+  """"""
+  name: String
+
+  """"""
+  value: String
+
+  """"""
+  source: String
+
+  """"""
+  description: String
+
+  """"""
+  keyFact: Boolean
+
+  """"""
+  type: FactType
+
+  """"""
+  category: String
+
+  """"""
+  references: [FactReference]
+
+  """"""
+  service: String
+}
+
+""""""
+enum FactType {
+  """"""
+  TEXT
+
+  """"""
+  URL
+
+  """"""
+  SEMVER
+}
+
+""""""
+type FactReference {
+  """"""
+  id: Int
+
+  """"""
+  fid: Int
+
+  """"""
+  name: String
+}
+
+""""""
+type Workflow {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  event: String
+
+  """"""
+  project: Int
+
+  """"""
+  advancedTaskDefinition: AdvancedTaskDefinition
+}
+
+""""""
+type DeployTargetConfig {
+  """"""
+  id: Int
+
+  """"""
+  project: Project
+
+  """"""
+  weight: Int
+
+  """"""
+  branches: String
+
+  """"""
+  pullrequests: String
+
+  """"""
+  deployTarget: Openshift
+
+  """"""
+  deployTargetProjectPattern: String
+}
+
+""""""
+type ProjectFactSearchResults {
+  """"""
+  count: Int
+
+  """"""
+  projects: [Project]
+}
+
+""""""
+type EnvironmentFactSearchResults {
+  """"""
+  count: Int
+
+  """"""
+  environments: [Environment]
+}
+
+""""""
+enum DeploymentStatusType {
+  """"""
+  NEW
+
+  """"""
+  PENDING
+
+  """"""
+  RUNNING
+
+  """"""
+  CANCELLED
+
+  """"""
+  ERROR
+
+  """"""
+  FAILED
+
+  """"""
+  COMPLETE
+}
+
+""""""
+enum ProjectOrderType {
+  """"""
+  NAME
+
+  """"""
+  CREATED
+}
+
+""""""
+input MetadataKeyValue {
+  """"""
+  key: String!
+
+  """"""
+  value: String
+}
+
+""""""
+enum EnvOrderType {
+  """"""
+  NAME
+
+  """"""
+  UPDATED
+}
+
+""""""
+input GroupInput {
+  """"""
+  id: String
+
+  """"""
+  name: String
+}
+
+""""""
+type ProblemHarborScanMatch {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  description: String
+
+  """"""
+  defaultLagoonProject: String
+
+  """"""
+  defaultLagoonEnvironment: String
+
+  """"""
+  defaultLagoonService: String
+
+  """"""
+  regex: String
+}
+
+""""""
+type Mutation {
+  """Add Environment or update if it is already existing"""
+  addOrUpdateEnvironment(input: AddEnvironmentInput!): Environment
+
+  """"""
+  updateEnvironment(input: UpdateEnvironmentInput!): Environment
+
+  """"""
+  deleteEnvironment(input: DeleteEnvironmentInput!): String
+
+  """"""
+  deleteAllEnvironments: String
+
+  """Add or update Storage Information for Environment"""
+  addOrUpdateEnvironmentStorage(input: AddOrUpdateEnvironmentStorageInput!): EnvironmentStorage
+
+  """"""
+  addNotificationSlack(input: AddNotificationSlackInput!): NotificationSlack
+
+  """"""
+  updateNotificationSlack(input: UpdateNotificationSlackInput!): NotificationSlack
+
+  """"""
+  deleteNotificationSlack(input: DeleteNotificationSlackInput!): String
+
+  """"""
+  deleteAllNotificationSlacks: String
+
+  """"""
+  addNotificationRocketChat(input: AddNotificationRocketChatInput!): NotificationRocketChat
+
+  """"""
+  updateNotificationRocketChat(input: UpdateNotificationRocketChatInput!): NotificationRocketChat
+
+  """"""
+  deleteNotificationRocketChat(input: DeleteNotificationRocketChatInput!): String
+
+  """"""
+  deleteAllNotificationRocketChats: String
+
+  """"""
+  addNotificationMicrosoftTeams(input: AddNotificationMicrosoftTeamsInput!): NotificationMicrosoftTeams
+
+  """"""
+  updateNotificationMicrosoftTeams(input: UpdateNotificationMicrosoftTeamsInput!): NotificationMicrosoftTeams
+
+  """"""
+  deleteNotificationMicrosoftTeams(input: DeleteNotificationMicrosoftTeamsInput!): String
+
+  """"""
+  deleteAllNotificationMicrosoftTeams: String
+
+  """"""
+  addNotificationWebhook(input: AddNotificationWebhookInput!): NotificationWebhook
+
+  """"""
+  updateNotificationWebhook(input: UpdateNotificationWebhookInput!): NotificationWebhook
+
+  """"""
+  deleteNotificationWebhook(input: DeleteNotificationWebhookInput!): String
+
+  """"""
+  deleteAllNotificationWebhook: String
+
+  """"""
+  addNotificationEmail(input: AddNotificationEmailInput!): NotificationEmail
+
+  """"""
+  updateNotificationEmail(input: UpdateNotificationEmailInput!): NotificationEmail
+
+  """"""
+  deleteNotificationEmail(input: DeleteNotificationEmailInput!): String
+
+  """"""
+  deleteAllNotificationEmails: String
+
+  """Connect previous created Notification to a Project"""
+  addNotificationToProject(input: AddNotificationToProjectInput!): Project
+
+  """"""
+  removeNotificationFromProject(input: RemoveNotificationFromProjectInput!): Project
+
+  """"""
+  removeAllNotificationsFromAllProjects: String
+
+  """"""
+  addOpenshift(input: AddOpenshiftInput!): Openshift
+
+  """"""
+  updateOpenshift(input: UpdateOpenshiftInput!): Openshift
+
+  """"""
+  deleteOpenshift(input: DeleteOpenshiftInput!): String
+
+  """"""
+  deleteAllOpenshifts: String
+
+  """"""
+  addKubernetes(input: AddKubernetesInput!): Kubernetes
+
+  """"""
+  updateKubernetes(input: UpdateKubernetesInput!): Kubernetes
+
+  """"""
+  deleteKubernetes(input: DeleteKubernetesInput!): String
+
+  """"""
+  deleteAllKubernetes: String
+
+  """"""
+  addProject(input: AddProjectInput!): Project
+
+  """"""
+  updateProject(input: UpdateProjectInput!): Project
+
+  """"""
+  deleteProject(input: DeleteProjectInput!): String
+
+  """"""
+  deleteAllProjects: String
+
+  """"""
+  addSshKey(input: AddSshKeyInput!): SshKey
+
+  """"""
+  updateSshKey(input: UpdateSshKeyInput!): SshKey
+
+  """"""
+  deleteSshKey(input: DeleteSshKeyInput!): String
+
+  """"""
+  deleteSshKeyById(input: DeleteSshKeyByIdInput!): String
+
+  """"""
+  deleteAllSshKeys: String
+
+  """"""
+  removeAllSshKeysFromAllUsers: String
+
+  """"""
+  addUser(input: AddUserInput!): User
+
+  """"""
+  updateUser(input: UpdateUserInput!): User
+
+  """"""
+  deleteUser(input: DeleteUserInput!): String
+
+  """"""
+  deleteAllUsers: String
+
+  """"""
+  addDeployment(input: AddDeploymentInput!): Deployment
+
+  """"""
+  bulkDeployEnvironmentLatest(input: BulkDeploymentLatestInput!): String
+
+  """"""
+  deleteDeployment(input: DeleteDeploymentInput!): String
+
+  """"""
+  updateDeployment(input: UpdateDeploymentInput): Deployment
+
+  """"""
+  cancelDeployment(input: CancelDeploymentInput!): String
+
+  """"""
+  addBackup(input: AddBackupInput!): Backup
+
+  """"""
+  addProblem(input: AddProblemInput!): Problem
+
+  """"""
+  addProblemHarborScanMatch(input: AddProblemHarborScanMatchInput!): ProblemHarborScanMatch
+
+  """"""
+  deleteProblem(input: DeleteProblemInput!): String
+
+  """"""
+  deleteProblemsFromSource(input: DeleteProblemsFromSourceInput!): String
+
+  """"""
+  deleteProblemHarborScanMatch(input: DeleteProblemHarborScanMatchInput!): String
+
+  """"""
+  addFact(input: AddFactInput!): Fact
+
+  """"""
+  addFacts(input: AddFactsInput!): [Fact]
+
+  """"""
+  deleteFact(input: DeleteFactInput!): String
+
+  """"""
+  deleteFactsFromSource(input: DeleteFactsFromSourceInput!): String
+
+  """"""
+  addFactReference(input: AddFactReferenceInput!): FactReference
+
+  """"""
+  deleteFactReference(input: DeleteFactReferenceInput!): String
+
+  """"""
+  deleteAllFactReferencesByFactId(input: DeleteFactReferencesByFactIdInput!): String
+
+  """"""
+  deleteBackup(input: DeleteBackupInput!): String
+
+  """"""
+  deleteAllBackups: String
+
+  """"""
+  addRestore(input: AddRestoreInput!): Restore
+
+  """"""
+  updateRestore(input: UpdateRestoreInput!): Restore
+
+  """"""
+  addEnvVariable(input: EnvVariableInput!): EnvKeyValue
+
+  """"""
+  deleteEnvVariable(input: DeleteEnvVariableInput!): String
+
+  """"""
+  addTask(input: TaskInput!): Task
+
+  """"""
+  addAdvancedTaskDefinition(input: AdvancedTaskDefinitionInput!): AdvancedTaskDefinition
+
+  """"""
+  updateAdvancedTaskDefinition(input: UpdateAdvancedTaskDefinitionInput!): AdvancedTaskDefinition
+
+  """"""
+  invokeRegisteredTask(advancedTaskDefinition: Int!, environment: Int!, argumentValues: [AdvancedTaskDefinitionArgumentValueInput]): Task
+
+  """"""
+  deleteAdvancedTaskDefinition(advancedTaskDefinition: Int!): String
+
+  """"""
+  addWorkflow(input: AddWorkflowInput!): Workflow
+
+  """"""
+  updateWorkflow(input: UpdateWorkflowInput): Workflow
+
+  """"""
+  deleteWorkflow(input: DeleteWorkflowInput!): String
+
+  """"""
+  taskDrushArchiveDump(environment: Int!): Task
+
+  """"""
+  taskDrushSqlDump(environment: Int!): Task
+
+  """"""
+  taskDrushCacheClear(environment: Int!): Task
+
+  """"""
+  taskDrushCron(environment: Int!): Task
+
+  """"""
+  taskDrushSqlSync(sourceEnvironment: Int!, destinationEnvironment: Int!): Task
+
+  """"""
+  taskDrushRsyncFiles(sourceEnvironment: Int!, destinationEnvironment: Int!): Task
+
+  """"""
+  taskDrushUserLogin(environment: Int!): Task
+
+  """"""
+  deleteTask(input: DeleteTaskInput!): String
+
+  """"""
+  updateTask(input: UpdateTaskInput): Task
+
+  """"""
+  setEnvironmentServices(input: SetEnvironmentServicesInput!): [EnvironmentService]
+
+  """"""
+  uploadFilesForTask(input: UploadFilesForTaskInput!): Task
+
+  """"""
+  deleteFilesForTask(input: DeleteFilesForTaskInput!): String
+
+  """"""
+  deployEnvironmentLatest(input: DeployEnvironmentLatestInput!): String
+
+  """"""
+  deployEnvironmentBranch(input: DeployEnvironmentBranchInput!): String
+
+  """"""
+  deployEnvironmentPullrequest(input: DeployEnvironmentPullrequestInput!): String
+
+  """"""
+  deployEnvironmentPromote(input: DeployEnvironmentPromoteInput!): String
+
+  """"""
+  switchActiveStandby(input: switchActiveStandbyInput!): Task
+
+  """"""
+  addGroup(input: AddGroupInput!): GroupInterface
+
+  """"""
+  updateGroup(input: UpdateGroupInput!): GroupInterface
+
+  """"""
+  deleteGroup(input: DeleteGroupInput!): String
+
+  """"""
+  deleteAllGroups: String
+
+  """"""
+  addUserToGroup(input: UserGroupRoleInput!): GroupInterface
+
+  """"""
+  removeUserFromGroup(input: UserGroupInput!): GroupInterface
+
+  """"""
+  addGroupsToProject(input: ProjectGroupsInput): Project
+
+  """"""
+  removeGroupsFromProject(input: ProjectGroupsInput!): Project
+
+  """"""
+  updateProjectMetadata(input: UpdateMetadataInput!): Project
+
+  """"""
+  removeProjectMetadataByKey(input: RemoveMetadataInput!): Project
+
+  """"""
+  addDeployTargetConfig(input: AddDeployTargetConfigInput!): DeployTargetConfig @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+
+  """"""
+  updateDeployTargetConfig(input: UpdateDeployTargetConfigInput!): DeployTargetConfig @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+
+  """"""
+  deleteDeployTargetConfig(input: DeleteDeployTargetConfigInput!): String @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+
+  """"""
+  deleteAllDeployTargetConfigs: String @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+
+  """"""
+  updateEnvironmentDeployTarget(environment: Int!, deployTarget: Int!): Environment
+}
+
+""""""
+input AddEnvironmentInput {
+  """"""
+  id: Int
+
+  """"""
+  name: String!
+
+  """"""
+  project: Int!
+
+  """"""
+  deployType: DeployType!
+
+  """"""
+  deployBaseRef: String!
+
+  """"""
+  deployHeadRef: String
+
+  """"""
+  deployTitle: String
+
+  """"""
+  environmentType: EnvType!
+
+  """"""
+  openshiftProjectName: String
+
+  """"""
+  kubernetesNamespaceName: String
+
+  """"""
+  openshift: Int
+
+  """"""
+  openshiftProjectPattern: String
+
+  """"""
+  kubernetes: Int
+
+  """"""
+  kubernetesNamespacePattern: String
+}
+
+""""""
+enum DeployType {
+  """"""
+  BRANCH
+
+  """"""
+  PULLREQUEST
+
+  """"""
+  PROMOTE
+}
+
+""""""
+input UpdateEnvironmentInput {
+  """"""
+  id: Int!
+
+  """"""
+  patch: UpdateEnvironmentPatchInput
+}
+
+""""""
+input UpdateEnvironmentPatchInput {
+  """"""
+  project: Int
+
+  """"""
+  deployType: DeployType
+
+  """"""
+  deployBaseRef: String
+
+  """"""
+  deployHeadRef: String
+
+  """"""
+  deployTitle: String
+
+  """"""
+  environmentType: EnvType
+
+  """"""
+  openshiftProjectName: String
+
+  """"""
+  kubernetesNamespaceName: String
+
+  """"""
+  route: String
+
+  """"""
+  routes: String
+
+  """"""
+  monitoringUrls: String
+
+  """"""
+  autoIdle: Int
+
+  """"""
+  openshift: Int
+
+  """"""
+  openshiftProjectPattern: String
+
+  """"""
+  kubernetes: Int
+
+  """"""
+  kubernetesNamespacePattern: String
+
+  """Timestamp in format 'YYYY-MM-DD hh:mm:ss'"""
+  created: String
+}
+
+""""""
+input DeleteEnvironmentInput {
+  """"""
+  name: String!
+
+  """"""
+  project: String!
+
+  """"""
+  execute: Boolean
+}
+
+""""""
+input AddOrUpdateEnvironmentStorageInput {
+  """"""
+  environment: Int!
+
+  """"""
+  persistentStorageClaim: String!
+
+  """"""
+  bytesUsed: Int!
+
+  """Date in format 'YYYY-MM-DD'"""
+  updated: String
+}
+
+""""""
+input AddNotificationSlackInput {
+  """"""
+  name: String!
+
+  """"""
+  webhook: String!
+
+  """"""
+  channel: String!
+}
+
+""""""
+input UpdateNotificationSlackInput {
+  """"""
+  name: String!
+
+  """"""
+  patch: UpdateNotificationSlackPatchInput
+}
+
+""""""
+input UpdateNotificationSlackPatchInput {
+  """"""
+  name: String
+
+  """"""
+  webhook: String
+
+  """"""
+  channel: String
+}
+
+""""""
+input DeleteNotificationSlackInput {
+  """"""
+  name: String!
+}
+
+""""""
+input AddNotificationRocketChatInput {
+  """"""
+  name: String!
+
+  """"""
+  webhook: String!
+
+  """"""
+  channel: String!
+}
+
+""""""
+input UpdateNotificationRocketChatInput {
+  """"""
+  name: String!
+
+  """"""
+  patch: UpdateNotificationRocketChatPatchInput
+}
+
+""""""
+input UpdateNotificationRocketChatPatchInput {
+  """"""
+  name: String
+
+  """"""
+  webhook: String
+
+  """"""
+  channel: String
+}
+
+""""""
+input DeleteNotificationRocketChatInput {
+  """"""
+  name: String!
+}
+
+""""""
+input AddNotificationMicrosoftTeamsInput {
+  """"""
+  name: String!
+
+  """"""
+  webhook: String!
+}
+
+""""""
+input UpdateNotificationMicrosoftTeamsInput {
+  """"""
+  name: String!
+
+  """"""
+  patch: UpdateNotificationMicrosoftTeamsPatchInput
+}
+
+""""""
+input UpdateNotificationMicrosoftTeamsPatchInput {
+  """"""
+  name: String
+
+  """"""
+  webhook: String
+
+  """"""
+  channel: String
+}
+
+""""""
+input DeleteNotificationMicrosoftTeamsInput {
+  """"""
+  name: String!
+}
+
+""""""
+input AddNotificationWebhookInput {
+  """"""
+  name: String!
+
+  """"""
+  webhook: String!
+}
+
+""""""
+input UpdateNotificationWebhookInput {
+  """"""
+  name: String!
+
+  """"""
+  patch: UpdateNotificationWebhookPatchInput
+}
+
+""""""
+input UpdateNotificationWebhookPatchInput {
+  """"""
+  name: String
+
+  """"""
+  webhook: String
+}
+
+""""""
+input DeleteNotificationWebhookInput {
+  """"""
+  name: String!
+}
+
+""""""
+input AddNotificationEmailInput {
+  """"""
+  name: String!
+
+  """"""
+  emailAddress: String!
+}
+
+""""""
+input UpdateNotificationEmailInput {
+  """"""
+  name: String!
+
+  """"""
+  patch: UpdateNotificationEmailPatchInput
+}
+
+""""""
+input UpdateNotificationEmailPatchInput {
+  """"""
+  name: String
+
+  """"""
+  emailAddress: String
+}
+
+""""""
+input DeleteNotificationEmailInput {
+  """"""
+  name: String!
+}
+
+""""""
+input AddNotificationToProjectInput {
+  """"""
+  project: String!
+
+  """"""
+  notificationType: NotificationType!
+
+  """"""
+  notificationName: String!
+
+  """"""
+  contentType: NotificationContentType
+
+  """"""
+  notificationSeverityThreshold: ProblemSeverityRating
+}
+
+""""""
+input RemoveNotificationFromProjectInput {
+  """"""
+  project: String!
+
+  """"""
+  notificationType: NotificationType!
+
+  """"""
+  notificationName: String!
+}
+
+""""""
+input AddOpenshiftInput {
+  """"""
+  id: Int
+
+  """"""
+  name: String!
+
+  """"""
+  consoleUrl: String!
+
+  """"""
+  token: String
+
+  """"""
+  routerPattern: String
+
+  """@deprecated(reason: "Not used with RBAC permissions")"""
+  projectUser: String
+
+  """"""
+  sshHost: String
+
+  """"""
+  sshPort: String
+
+  """"""
+  monitoringConfig: JSON
+
+  """"""
+  friendlyName: String
+
+  """"""
+  cloudProvider: String
+
+  """"""
+  cloudRegion: String
+
+  """"""
+  buildImage: String
+}
+
+""""""
+input UpdateOpenshiftInput {
+  """"""
+  id: Int!
+
+  """"""
+  patch: UpdateOpenshiftPatchInput!
+}
+
+""""""
+input UpdateOpenshiftPatchInput {
+  """"""
+  name: String
+
+  """"""
+  consoleUrl: String
+
+  """"""
+  token: String
+
+  """"""
+  routerPattern: String
+
+  """@deprecated(reason: "Not used with RBAC permissions")"""
+  projectUser: String
+
+  """"""
+  sshHost: String
+
+  """"""
+  sshPort: String
+
+  """"""
+  monitoringConfig: JSON
+
+  """"""
+  friendlyName: String
+
+  """"""
+  cloudProvider: String
+
+  """"""
+  cloudRegion: String
+
+  """"""
+  buildImage: String
+}
+
+""""""
+input DeleteOpenshiftInput {
+  """"""
+  name: String!
+}
+
+""""""
+input AddKubernetesInput {
+  """"""
+  id: Int
+
+  """"""
+  name: String!
+
+  """"""
+  consoleUrl: String!
+
+  """"""
+  token: String
+
+  """"""
+  routerPattern: String
+
+  """@deprecated(reason: "Not used with RBAC permissions")"""
+  projectUser: String
+
+  """"""
+  sshHost: String
+
+  """"""
+  sshPort: String
+
+  """"""
+  monitoringConfig: JSON
+
+  """"""
+  friendlyName: String
+
+  """"""
+  cloudProvider: String
+
+  """"""
+  cloudRegion: String
+
+  """"""
+  buildImage: String
+}
+
+""""""
+input UpdateKubernetesInput {
+  """"""
+  id: Int!
+
+  """"""
+  patch: UpdateKubernetesPatchInput!
+}
+
+""""""
+input UpdateKubernetesPatchInput {
+  """"""
+  name: String
+
+  """"""
+  consoleUrl: String
+
+  """"""
+  token: String
+
+  """"""
+  routerPattern: String
+
+  """@deprecated(reason: "Not used with RBAC permissions")"""
+  projectUser: String
+
+  """"""
+  sshHost: String
+
+  """"""
+  sshPort: String
+
+  """"""
+  monitoringConfig: JSON
+
+  """"""
+  friendlyName: String
+
+  """"""
+  cloudProvider: String
+
+  """"""
+  cloudRegion: String
+
+  """"""
+  buildImage: String
+}
+
+""""""
+input DeleteKubernetesInput {
+  """"""
+  name: String!
+}
+
+""""""
+input AddProjectInput {
+  """"""
+  id: Int
+
+  """"""
+  name: String!
+
+  """"""
+  gitUrl: String!
+
+  """"""
+  subfolder: String
+
+  """"""
+  routerPattern: String
+
+  """"""
+  openshift: Int
+
+  """"""
+  openshiftProjectPattern: String
+
+  """"""
+  kubernetes: Int
+
+  """"""
+  kubernetesNamespacePattern: String
+
+  """"""
+  activeSystemsDeploy: String
+
+  """"""
+  activeSystemsPromote: String
+
+  """"""
+  activeSystemsRemove: String
+
+  """"""
+  activeSystemsTask: String
+
+  """"""
+  activeSystemsMisc: String
+
+  """"""
+  branches: String
+
+  """"""
+  pullrequests: String
+
+  """"""
+  productionEnvironment: String!
+
+  """"""
+  productionRoutes: String
+
+  """"""
+  productionAlias: String
+
+  """"""
+  standbyProductionEnvironment: String
+
+  """"""
+  standbyRoutes: String
+
+  """"""
+  standbyAlias: String
+
+  """"""
+  availability: ProjectAvailability
+
+  """"""
+  autoIdle: Int
+
+  """"""
+  storageCalc: Int
+
+  """"""
+  developmentEnvironmentsLimit: Int
+
+  """"""
+  privateKey: String
+
+  """"""
+  problemsUi: Int
+
+  """"""
+  factsUi: Int
+
+  """"""
+  productionBuildPriority: Int
+
+  """"""
+  developmentBuildPriority: Int
+
+  """"""
+  deploymentsDisabled: Int
+}
+
+""""""
+input UpdateProjectInput {
+  """"""
+  id: Int!
+
+  """"""
+  patch: UpdateProjectPatchInput!
+}
+
+""""""
+input UpdateProjectPatchInput {
+  """"""
+  name: String
+
+  """"""
+  gitUrl: String
+
+  """"""
+  availability: ProjectAvailability
+
+  """"""
+  privateKey: String
+
+  """"""
+  subfolder: String
+
+  """"""
+  routerPattern: String
+
+  """"""
+  activeSystemsDeploy: String
+
+  """"""
+  activeSystemsRemove: String
+
+  """"""
+  activeSystemsTask: String
+
+  """"""
+  activeSystemsMisc: String
+
+  """"""
+  activeSystemsPromote: String
+
+  """"""
+  branches: String
+
+  """"""
+  productionEnvironment: String
+
+  """"""
+  productionRoutes: String
+
+  """"""
+  productionAlias: String
+
+  """"""
+  standbyProductionEnvironment: String
+
+  """"""
+  standbyRoutes: String
+
+  """"""
+  standbyAlias: String
+
+  """"""
+  autoIdle: Int
+
+  """"""
+  storageCalc: Int
+
+  """"""
+  pullrequests: String
+
+  """"""
+  openshift: Int
+
+  """"""
+  openshiftProjectPattern: String
+
+  """"""
+  kubernetes: Int
+
+  """"""
+  kubernetesNamespacePattern: String
+
+  """"""
+  developmentEnvironmentsLimit: Int
+
+  """"""
+  problemsUi: Int
+
+  """"""
+  factsUi: Int
+
+  """"""
+  productionBuildPriority: Int
+
+  """"""
+  developmentBuildPriority: Int
+
+  """"""
+  deploymentsDisabled: Int
+}
+
+""""""
+input DeleteProjectInput {
+  """"""
+  project: String!
+}
+
+""""""
+input AddSshKeyInput {
+  """"""
+  id: Int
+
+  """"""
+  name: String!
+
+  """"""
+  keyValue: String!
+
+  """"""
+  keyType: SshKeyType!
+
+  """"""
+  user: UserInput!
+}
+
+""""""
+enum SshKeyType {
+  """"""
+  SSH_RSA
+
+  """"""
+  SSH_ED25519
+
+  """"""
+  ECDSA_SHA2_NISTP256
+
+  """"""
+  ECDSA_SHA2_NISTP384
+
+  """"""
+  ECDSA_SHA2_NISTP521
+}
+
+""""""
+input UserInput {
+  """"""
+  id: String
+
+  """"""
+  email: String
+}
+
+""""""
+input UpdateSshKeyInput {
+  """"""
+  id: Int!
+
+  """"""
+  patch: UpdateSshKeyPatchInput!
+}
+
+""""""
+input UpdateSshKeyPatchInput {
+  """"""
+  name: String
+
+  """"""
+  keyValue: String
+
+  """"""
+  keyType: SshKeyType
+}
+
+""""""
+input DeleteSshKeyInput {
+  """"""
+  name: String!
+}
+
+""""""
+input DeleteSshKeyByIdInput {
+  """"""
+  id: Int!
+}
+
+""""""
+input AddUserInput {
+  """"""
+  email: String!
+
+  """"""
+  firstName: String
+
+  """"""
+  lastName: String
+
+  """"""
+  comment: String
+
+  """"""
+  gitlabId: Int
+}
+
+""""""
+input UpdateUserInput {
+  """"""
+  user: UserInput!
+
+  """"""
+  patch: UpdateUserPatchInput!
+}
+
+""""""
+input UpdateUserPatchInput {
+  """"""
+  email: String
+
+  """"""
+  firstName: String
+
+  """"""
+  lastName: String
+
+  """"""
+  comment: String
+
+  """"""
+  gitlabId: Int
+}
+
+""""""
+input DeleteUserInput {
+  """"""
+  user: UserInput!
+}
+
+""""""
+input AddDeploymentInput {
+  """"""
+  id: Int
+
+  """"""
+  name: String!
+
+  """"""
+  status: DeploymentStatusType!
+
+  """"""
+  created: String!
+
+  """"""
+  started: String
+
+  """"""
+  completed: String
+
+  """"""
+  environment: Int!
+
+  """"""
+  remoteId: String
+
+  """"""
+  priority: Int
+
+  """"""
+  bulkId: String
+
+  """"""
+  bulkName: String
+}
+
+""""""
+input BulkDeploymentLatestInput {
+  """"""
+  buildVariables: [EnvKeyValueInput]
+
+  """"""
+  environments: [DeployEnvironmentLatestInput!]!
+
+  """"""
+  name: String
+}
+
+""""""
+input EnvKeyValueInput {
+  """"""
+  name: String
+
+  """"""
+  value: String
+}
+
+""""""
+input DeployEnvironmentLatestInput {
+  """"""
+  environment: EnvironmentInput!
+
+  """"""
+  priority: Int
+
+  """"""
+  bulkId: String
+
+  """"""
+  bulkName: String
+
+  """"""
+  buildVariables: [EnvKeyValueInput]
+
+  """"""
+  returnData: Boolean
+}
+
+"""Must provide id OR name and project"""
+input EnvironmentInput {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  project: ProjectInput
+}
+
+"""Must provide id OR name"""
+input ProjectInput {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+}
+
+""""""
+input DeleteDeploymentInput {
+  """"""
+  id: Int!
+}
+
+""""""
+input UpdateDeploymentInput {
+  """"""
+  id: Int!
+
+  """"""
+  patch: UpdateDeploymentPatchInput!
+}
+
+""""""
+input UpdateDeploymentPatchInput {
+  """"""
+  name: String
+
+  """"""
+  status: DeploymentStatusType
+
+  """"""
+  created: String
+
+  """"""
+  started: String
+
+  """"""
+  completed: String
+
+  """"""
+  environment: Int
+
+  """"""
+  remoteId: String
+
+  """"""
+  priority: Int
+
+  """"""
+  bulkId: String
+
+  """"""
+  bulkName: String
+}
+
+""""""
+input CancelDeploymentInput {
+  """"""
+  deployment: DeploymentInput!
+}
+
+"""Must provide id OR name and environment"""
+input DeploymentInput {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  environment: EnvironmentInput
+}
+
+""""""
+input AddBackupInput {
+  """"""
+  id: Int
+
+  """"""
+  environment: Int!
+
+  """"""
+  source: String!
+
+  """"""
+  backupId: String!
+
+  """"""
+  created: String!
+}
+
+""""""
+input AddProblemInput {
+  """"""
+  id: Int
+
+  """"""
+  environment: Int!
+
+  """"""
+  severity: ProblemSeverityRating
+
+  """"""
+  severityScore: SeverityScore
+
+  """"""
+  identifier: String!
+
+  """"""
+  service: String
+
+  """"""
+  source: String!
+
+  """"""
+  associatedPackage: String
+
+  """"""
+  description: String
+
+  """"""
+  links: String
+
+  """"""
+  version: String
+
+  """"""
+  fixedVersion: String
+
+  """"""
+  data: String!
+
+  """"""
+  created: String
+}
+
+""""""
+input AddProblemHarborScanMatchInput {
+  """"""
+  name: String!
+
+  """"""
+  description: String!
+
+  """"""
+  defaultLagoonProject: String
+
+  """"""
+  defaultLagoonEnvironment: String
+
+  """"""
+  defaultLagoonService: String
+
+  """"""
+  regex: String!
+}
+
+""""""
+input DeleteProblemInput {
+  """"""
+  environment: Int!
+
+  """"""
+  identifier: String!
+}
+
+""""""
+input DeleteProblemsFromSourceInput {
+  """"""
+  environment: Int!
+
+  """"""
+  source: String!
+
+  """"""
+  service: String!
+}
+
+""""""
+input DeleteProblemHarborScanMatchInput {
+  """"""
+  id: Int!
+}
+
+""""""
+input AddFactInput {
+  """"""
+  id: Int
+
+  """"""
+  environment: Int!
+
+  """"""
+  name: String!
+
+  """"""
+  value: String!
+
+  """"""
+  source: String!
+
+  """"""
+  description: String!
+
+  """"""
+  keyFact: Boolean
+
+  """"""
+  type: FactType
+
+  """"""
+  category: String
+
+  """"""
+  service: String
+}
+
+""""""
+input AddFactsInput {
+  """"""
+  facts: [AddFactInput]!
+}
+
+""""""
+input DeleteFactInput {
+  """"""
+  environment: Int!
+
+  """"""
+  name: String!
+}
+
+""""""
+input DeleteFactsFromSourceInput {
+  """"""
+  environment: Int!
+
+  """"""
+  source: String!
+}
+
+""""""
+input AddFactReferenceInput {
+  """"""
+  fid: Int!
+
+  """"""
+  name: String!
+}
+
+""""""
+input DeleteFactReferenceInput {
+  """"""
+  factName: String!
+
+  """"""
+  referenceName: String!
+
+  """"""
+  eid: Int!
+}
+
+""""""
+input DeleteFactReferencesByFactIdInput {
+  """"""
+  fid: Int!
+}
+
+""""""
+input DeleteBackupInput {
+  """"""
+  backupId: String!
+}
+
+""""""
+input AddRestoreInput {
+  """"""
+  id: Int
+
+  """"""
+  status: RestoreStatusType
+
+  """"""
+  restoreLocation: String
+
+  """"""
+  created: String
+
+  """"""
+  execute: Boolean
+
+  """"""
+  backupId: String!
+}
+
+""""""
+enum RestoreStatusType {
+  """"""
+  PENDING
+
+  """"""
+  SUCCESSFUL
+
+  """"""
+  FAILED
+}
+
+""""""
+input UpdateRestoreInput {
+  """"""
+  backupId: String!
+
+  """"""
+  patch: UpdateRestorePatchInput!
+}
+
+""""""
+input UpdateRestorePatchInput {
+  """"""
+  status: RestoreStatusType
+
+  """"""
+  created: String
+
+  """"""
+  restoreLocation: String
+}
+
+""""""
+input EnvVariableInput {
+  """"""
+  id: Int
+
+  """"""
+  type: EnvVariableType
+
+  """"""
+  typeId: Int!
+
+  """"""
+  scope: EnvVariableScope
+
+  """"""
+  name: String!
+
+  """"""
+  value: String!
+}
+
+""""""
+enum EnvVariableType {
+  """"""
+  PROJECT
+
+  """"""
+  ENVIRONMENT
+}
+
+""""""
+enum EnvVariableScope {
+  """"""
+  BUILD
+
+  """"""
+  RUNTIME
+
+  """"""
+  GLOBAL
+
+  """"""
+  CONTAINER_REGISTRY
+
+  """"""
+  INTERNAL_CONTAINER_REGISTRY
+}
+
+""""""
+input DeleteEnvVariableInput {
+  """"""
+  id: Int!
+}
+
+""""""
+input TaskInput {
+  """"""
+  id: Int
+
+  """"""
+  name: String!
+
+  """"""
+  status: TaskStatusType
+
+  """"""
+  created: String
+
+  """"""
+  started: String
+
+  """"""
+  completed: String
+
+  """"""
+  environment: Int!
+
+  """"""
+  service: String
+
+  """"""
+  command: String
+
+  """"""
+  remoteId: String
+
+  """"""
+  execute: Boolean
+}
+
+""""""
+enum TaskStatusType {
+  """"""
+  ACTIVE
+
+  """"""
+  SUCCEEDED
+
+  """"""
+  FAILED
+
+  """"""
+  NEW
+
+  """"""
+  PENDING
+
+  """"""
+  RUNNING
+
+  """"""
+  CANCELLED
+
+  """"""
+  ERROR
+
+  """"""
+  COMPLETE
+}
+
+""""""
+input AdvancedTaskDefinitionInput {
+  """"""
+  name: String
+
+  """"""
+  description: String
+
+  """"""
+  image: String
+
+  """"""
+  type: AdvancedTaskDefinitionTypes
+
+  """"""
+  service: String
+
+  """"""
+  command: String
+
+  """"""
+  environment: Int
+
+  """"""
+  project: Int
+
+  """"""
+  groupName: String
+
+  """"""
+  permission: TaskPermission
+
+  """"""
+  advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgumentInput]
+
+  """"""
+  confirmationText: String
+}
+
+""""""
+input AdvancedTaskDefinitionArgumentInput {
+  """"""
+  name: String
+
+  """"""
+  type: AdvancedTaskDefinitionArgumentTypes
+
+  """"""
+  displayName: String
+}
+
+""""""
+enum AdvancedTaskDefinitionArgumentTypes {
+  """"""
+  NUMERIC
+
+  """"""
+  STRING
+
+  """"""
+  ENVIRONMENT_SOURCE_NAME
+
+  """"""
+  ENVIRONMENT_SOURCE_NAME_EXCLUDE_SELF
+}
+
+""""""
+input UpdateAdvancedTaskDefinitionInput {
+  """"""
+  id: Int!
+
+  """"""
+  patch: UpdateAdvancedTaskDefinitionPatchInput!
+}
+
+""""""
+input UpdateAdvancedTaskDefinitionPatchInput {
+  """"""
+  name: String
+
+  """"""
+  description: String
+
+  """"""
+  image: String
+
+  """"""
+  type: AdvancedTaskDefinitionTypes
+
+  """"""
+  service: String
+
+  """"""
+  command: String
+
+  """"""
+  environment: Int
+
+  """"""
+  project: Int
+
+  """"""
+  groupName: String
+
+  """"""
+  permission: TaskPermission
+
+  """"""
+  advancedTaskDefinitionArguments: [AdvancedTaskDefinitionArgumentInput]
+
+  """"""
+  confirmationText: String
+}
+
+""""""
+input AdvancedTaskDefinitionArgumentValueInput {
+  """"""
+  advancedTaskDefinitionArgumentName: String
+
+  """"""
+  value: String
+}
+
+""""""
+input AddWorkflowInput {
+  """"""
+  name: String
+
+  """"""
+  event: String
+
+  """"""
+  project: Int
+
+  """"""
+  advancedTaskDefinition: Int
+}
+
+""""""
+input UpdateWorkflowInput {
+  """"""
+  id: Int!
+
+  """"""
+  patch: UpdateWorkflowPatchInput!
+}
+
+""""""
+input UpdateWorkflowPatchInput {
+  """"""
+  name: String
+
+  """"""
+  event: String
+
+  """"""
+  project: Int
+
+  """"""
+  advancedTaskDefinition: Int
+}
+
+""""""
+input DeleteWorkflowInput {
+  """"""
+  id: Int!
+}
+
+""""""
+input DeleteTaskInput {
+  """"""
+  id: Int!
+}
+
+""""""
+input UpdateTaskInput {
+  """"""
+  id: Int!
+
+  """"""
+  patch: UpdateTaskPatchInput!
+}
+
+""""""
+input UpdateTaskPatchInput {
+  """"""
+  name: String
+
+  """"""
+  taskName: String
+
+  """"""
+  status: TaskStatusType
+
+  """"""
+  created: String
+
+  """"""
+  started: String
+
+  """"""
+  completed: String
+
+  """"""
+  environment: Int
+
+  """"""
+  service: String
+
+  """"""
+  command: String
+
+  """"""
+  remoteId: String
+}
+
+""""""
+input SetEnvironmentServicesInput {
+  """"""
+  environment: Int!
+
+  """"""
+  services: [String]!
+}
+
+""""""
+input UploadFilesForTaskInput {
+  """"""
+  task: Int!
+
+  """"""
+  files: [Upload]!
+}
+
+"""The `Upload` scalar type represents a file upload."""
+scalar Upload
+
+""""""
+input DeleteFilesForTaskInput {
+  """"""
+  id: Int!
+}
+
+""""""
+input DeployEnvironmentBranchInput {
+  """"""
+  project: ProjectInput!
+
+  """"""
+  branchName: String!
+
+  """"""
+  branchRef: String
+
+  """"""
+  priority: Int
+
+  """"""
+  bulkId: String
+
+  """"""
+  bulkName: String
+
+  """"""
+  buildVariables: [EnvKeyValueInput]
+
+  """"""
+  returnData: Boolean
+}
+
+""""""
+input DeployEnvironmentPullrequestInput {
+  """"""
+  project: ProjectInput!
+
+  """"""
+  number: Int!
+
+  """"""
+  title: String!
+
+  """"""
+  baseBranchName: String!
+
+  """"""
+  baseBranchRef: String!
+
+  """"""
+  headBranchName: String!
+
+  """"""
+  headBranchRef: String!
+
+  """"""
+  priority: Int
+
+  """"""
+  bulkId: String
+
+  """"""
+  bulkName: String
+
+  """"""
+  buildVariables: [EnvKeyValueInput]
+
+  """"""
+  returnData: Boolean
+}
+
+""""""
+input DeployEnvironmentPromoteInput {
+  """"""
+  sourceEnvironment: EnvironmentInput!
+
+  """"""
+  project: ProjectInput!
+
+  """"""
+  destinationEnvironment: String!
+
+  """"""
+  priority: Int
+
+  """"""
+  bulkId: String
+
+  """"""
+  bulkName: String
+
+  """"""
+  buildVariables: [EnvKeyValueInput]
+
+  """"""
+  returnData: Boolean
+}
+
+""""""
+input switchActiveStandbyInput {
+  """"""
+  project: ProjectInput!
+}
+
+""""""
+input AddGroupInput {
+  """"""
+  name: String!
+
+  """"""
+  parentGroup: GroupInput
+}
+
+""""""
+input UpdateGroupInput {
+  """"""
+  group: GroupInput!
+
+  """"""
+  patch: UpdateGroupPatchInput!
+}
+
+""""""
+input UpdateGroupPatchInput {
+  """"""
+  name: String
+}
+
+""""""
+input DeleteGroupInput {
+  """"""
+  group: GroupInput!
+}
+
+""""""
+input UserGroupRoleInput {
+  """"""
+  user: UserInput!
+
+  """"""
+  group: GroupInput!
+
+  """"""
+  role: GroupRole!
+}
+
+""""""
+input UserGroupInput {
+  """"""
+  user: UserInput!
+
+  """"""
+  group: GroupInput!
+}
+
+""""""
+input ProjectGroupsInput {
+  """"""
+  project: ProjectInput!
+
+  """"""
+  groups: [GroupInput!]!
+}
+
+""""""
+input UpdateMetadataInput {
+  """"""
+  id: Int!
+
+  """"""
+  patch: MetadataKeyValue!
+}
+
+""""""
+input RemoveMetadataInput {
+  """"""
+  id: Int!
+
+  """"""
+  key: String!
+}
+
+""""""
+input AddDeployTargetConfigInput {
+  """"""
+  id: Int
+
+  """"""
+  project: Int!
+
+  """"""
+  weight: Int
+
+  """"""
+  branches: String!
+
+  """"""
+  pullrequests: String!
+
+  """"""
+  deployTarget: Int!
+
+  """"""
+  deployTargetProjectPattern: String
+}
+
+""""""
+input UpdateDeployTargetConfigInput {
+  """"""
+  id: Int!
+
+  """"""
+  patch: UpdateDeployTargetConfigPatchInput
+}
+
+""""""
+input UpdateDeployTargetConfigPatchInput {
+  """"""
+  weight: Int
+
+  """"""
+  branches: String
+
+  """"""
+  pullrequests: String
+
+  """"""
+  deployTarget: Int
+
+  """"""
+  deployTargetProjectPattern: String
+}
+
+""""""
+input DeleteDeployTargetConfigInput {
+  """"""
+  id: Int!
+
+  """"""
+  project: Int!
+
+  """"""
+  execute: Boolean
+}
+
+""""""
+type Subscription {
+  """"""
+  backupChanged(environment: Int!): Backup
+
+  """"""
+  deploymentChanged(environment: Int!): Deployment
+
+  """"""
+  taskChanged(environment: Int!): Task
+}
+
+""""""
+type TaskRegistration {
+  """"""
+  id: Int
+
+  """"""
+  type: String
+
+  """"""
+  name: String
+
+  """"""
+  description: String
+
+  """"""
+  groupName: String
+
+  """"""
+  environment: Int
+
+  """"""
+  project: Int
+
+  """"""
+  command: String
+
+  """"""
+  service: String
+
+  """"""
+  permission: TaskPermission
+
+  """"""
+  created: String
+
+  """"""
+  deleted: String
+}
+
+""""""
+input BulkProblem {
+  """"""
+  severity: ProblemSeverityRating
+
+  """"""
+  severityScore: SeverityScore
+
+  """"""
+  identifier: String
+
+  """"""
+  data: String
+}
+
+""""""
+input UpdateFactInputValue {
+  """"""
+  environment: Int!
+
+  """"""
+  name: String!
+
+  """"""
+  value: String!
+
+  """"""
+  source: String!
+
+  """"""
+  description: String
+
+  """"""
+  keyFact: Boolean
+
+  """"""
+  type: FactType
+
+  """"""
+  category: String
+
+  """"""
+  service: String
+}
+
+""""""
+input UpdateFactInput {
+  """"""
+  environment: Int!
+
+  """"""
+  patch: UpdateFactInputValue!
+}
+
+""""""
+input UpdateFactReferenceInputValue {
+  """"""
+  fid: Int!
+
+  """"""
+  name: String
+}
+
+""""""
+input UpdateFactReferenceInput {
+  """"""
+  fid: Int!
+
+  """"""
+  patch: UpdateFactReferenceInputValue!
+}
+
+""""""
+type Group implements GroupInterface {
+  """"""
+  id: String
+
+  """"""
+  name: String
+
+  """"""
+  type: String
+
+  """"""
+  groups: [GroupInterface]
+
+  """"""
+  members: [GroupMembership]
+
+  """"""
+  projects: [Project]
+}
+
+""""""
+type UnassignedNotification {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  type: String
+
+  """"""
+  contentType: String
+
+  """"""
+  notificationSeverityThreshold: ProblemSeverityRating
+}
+
+""""""
+type AdvancedTask {
+  """"""
+  id: Int
+
+  """"""
+  name: String
+
+  """"""
+  taskName: String
+
+  """"""
+  status: String
+
+  """"""
+  created: String
+
+  """"""
+  started: String
+
+  """"""
+  completed: String
+
+  """"""
+  environment: Environment
+
+  """"""
+  service: String
+
+  """"""
+  advancedTask: String
+
+  """"""
+  remoteId: String
+
+  """"""
+  logs: String
+
+  """"""
+  files: [File]
+}
+
+""""""
+input AdvancedTaskArgumentInput {
+  """"""
+  name: String
+
+  """"""
+  value: String
+}

--- a/api/tests/playbooks/environment_vars.yml
+++ b/api/tests/playbooks/environment_vars.yml
@@ -24,7 +24,7 @@
     - name: Delete Lagoon environment variable.
       lagoon.api.env_variable:
         state: absent
-        name: TEST_VAR_ENV_YHM
+        name: TEST_VAR_ENV
         type: ENVIRONMENT
         type_name: "{{ environment_ns }}"
         verify_value: true
@@ -34,7 +34,7 @@
         state: present
         type: ENVIRONMENT
         type_name: "{{ environment_ns }}"
-        name: TEST_VAR_ENV_YHM
+        name: TEST_VAR_ENV
         value: foo_bar
         scope: RUNTIME
         verify_value: true
@@ -51,7 +51,7 @@
         state: present
         type: ENVIRONMENT
         type_name: "{{ environment_ns }}"
-        name: TEST_VAR_ENV_YHM
+        name: TEST_VAR_ENV
         value: bar_baz
         scope: RUNTIME
         replace_existing: true
@@ -69,7 +69,7 @@
         state: absent
         type: ENVIRONMENT
         type_name: "{{ environment_ns }}"
-        name: TEST_VAR_ENV_YHM
+        name: TEST_VAR_ENV
         verify_value: true
 
     - name: Fetch environment vars.

--- a/api/tests/playbooks/lookup_vars.yml
+++ b/api/tests/playbooks/lookup_vars.yml
@@ -1,0 +1,23 @@
+- name: Lookup variables.
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  roles:
+  - lagoon.api.common
+  tasks:
+  - include_role:
+      name: lagoon.api.token
+
+  - name: lookup a project's variables
+    debug: msg="{{ item }}"
+    loop: "{{ lookup('lagoon.api.var', project_name) }}"
+
+  - name: lookup a project's variables as dict
+    debug: msg="{{ lookup('lagoon.api.var', project_name, return_dict=true) }}"
+
+  - name: retrieve a specific variable for a project
+    debug: msg='{{ lookup('lagoon.api.var', project_name, var_name=project_var_name) }}'
+
+  - name: retrieve variables for a project environment
+    debug: msg='{{ lookup('lagoon.api.var', project_name, environment='master') }}'

--- a/api/tests/playbooks/project_vars.yml
+++ b/api/tests/playbooks/project_vars.yml
@@ -24,7 +24,7 @@
     - name: Delete Lagoon environment variable.
       lagoon.api.env_variable:
         state: absent
-        name: TEST_VAR_YHM
+        name: TEST_VAR
         type: PROJECT
         type_name: "{{ project_name }}"
         verify_value: true
@@ -34,7 +34,7 @@
         state: present
         type: PROJECT
         type_name: "{{ project_name }}"
-        name: TEST_VAR_YHM
+        name: TEST_VAR
         value: foo_bar
         scope: RUNTIME
         verify_value: true
@@ -51,7 +51,7 @@
         state: present
         type: PROJECT
         type_name: "{{ project_name }}"
-        name: TEST_VAR_YHM
+        name: TEST_VAR
         value: bar_baz
         scope: RUNTIME
         replace_existing: true
@@ -67,7 +67,7 @@
     - name: Delete Lagoon environment variable.
       lagoon.api.env_variable:
         state: absent
-        name: TEST_VAR_YHM
+        name: TEST_VAR
         type: PROJECT
         type_name: "{{ project_name }}"
         verify_value: true

--- a/api/tests/unit/plugins/module_utils/test_gql.py
+++ b/api/tests/unit/plugins/module_utils/test_gql.py
@@ -1,7 +1,7 @@
 import unittest
 from ansible.module_utils.errors import AnsibleValidationError
 from ansible_collections.lagoon.api.tests.common import dsl_field_query_to_str, load_schema
-from gql.dsl import dsl_gql, DSLQuery, DSLSchema, print_ast
+from gql.dsl import DSLSchema
 
 import sys
 sys.modules['ansible.utils.display'] = unittest.mock.Mock()

--- a/api/tests/unit/plugins/module_utils/test_gql.py
+++ b/api/tests/unit/plugins/module_utils/test_gql.py
@@ -1,0 +1,40 @@
+import unittest
+from ansible.module_utils.errors import AnsibleValidationError
+from ansible_collections.lagoon.api.tests.common import dsl_field_query_to_str, load_schema
+from gql.dsl import dsl_gql, DSLQuery, DSLSchema, print_ast
+
+import sys
+sys.modules['ansible.utils.display'] = unittest.mock.Mock()
+from ansible_collections.lagoon.api.plugins.module_utils.gql import GqlClient
+
+
+class GqlTester(unittest.TestCase):
+
+    def test_client_constructor_missing_args(self):
+        with self.assertRaises(TypeError):
+            _ = GqlClient()
+
+        client = GqlClient('foo', 'bar')
+        assert client.display == None
+
+    def test_build_dynamic_query_missing_args(self):
+        client = GqlClient('foo', 'bar')
+
+        with self.assertRaises(TypeError):
+            client.build_dynamic_query()
+
+        with self.assertRaises(AnsibleValidationError):
+            client.build_dynamic_query('projectByName', 'Project')
+
+    def test_build_dynamic_query_missing_args(self):
+        client = GqlClient('foo', 'bar')
+        client.ds = DSLSchema(load_schema())
+        query = client.build_dynamic_query('projectByName', 'Project', fields=['id', 'name'])
+        query_str = dsl_field_query_to_str(query)
+        print(f"GraphQL built query: \n{query_str}")
+        assert query_str == """{
+  projectByName {
+    id
+    name
+  }
+}"""

--- a/api/tests/unit/requirements.txt
+++ b/api/tests/unit/requirements.txt
@@ -1,0 +1,5 @@
+ansible-core ; python_version >= '3.8'
+gql ; python_version >= '3.8'
+requests-toolbelt<1,>=0.9.1 ; python_version >= '3.8'
+urllib3>=1.26 ; python_version >= '3.8'
+requests<3,>=2.26 ; python_version >= '3.8'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: lagoon-collection-tester
+    volumes:
+      - ./api:/usr/share/collections/ansible_collections/lagoon/api
+    working_dir: /usr/share/collections/ansible_collections/lagoon/api


### PR DESCRIPTION
Big changes with this one:

- Created a LagoonLookupBase class for lookup plugins and refactored all lookup plugins to use that.
- Created an LagoonActionBase class for action plugins and refactored all actions plugins that were already using the GqlClient to use that.
- Moved API calls from existing GqlClient-based actions plugins to the module_utils classes instead.
- Updated the inventory plugin to use the new classes.
- Added a new dynamic query builder function in the GQL client as well as a `lagoon.api.query` action plugin.
- Added the scaffold for tests and a small test using a downloaded Lagoon GraphQL schema - updated the README with instructions on updating the schema & running the tests locally.
- Added a Github actions workflow to run the tests.