### PR TITLE
docs: added docs for action plugins

### DIFF
--- a/api/plugins/modules/deploy.py
+++ b/api/plugins/modules/deploy.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r'''
+module: deploy
+short_description: Deploy a project's branch
+description:
+    - Deploys a project's branch.
+options:
+  project:
+    description:
+      - The project name.
+    required: true
+    type: str
+  branch:
+    description:
+      - The project branch to deploy.
+    required: true
+    type: str
+  wait:
+    description:
+      - Wait for deployment completion before returning.
+    type: bool
+    default: False
+  delay:
+    description:
+      - Delay between checking deployment status when retrying.
+    type: int
+    default: 60
+  retries:
+    description:
+      - Number of times to check for deployment status before returning.
+    type: int
+    default: 30
+'''
+
+EXAMPLES = r'''
+- name: Trigger a deployment
+  lagoon.api.deploy:
+    project: test-project
+    branch: master
+    stagger: 5
+    retries: 60
+    wait: true
+'''

--- a/api/plugins/modules/deploy_bulk.py
+++ b/api/plugins/modules/deploy_bulk.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r'''
+module: deploy_bulk
+short_description: Start a Lagoon bulk deployment
+description:
+    - Starts a Lagoon bulk deployment.
+options:
+  build_vars:
+    description:
+      - List of build-time variables to set during the deployment.
+    type: list
+    elements: dict
+    default: []
+  name:
+    description:
+      - The bulk deployment name.
+    type: str
+    default: ""
+  environments:
+    description:
+      - List of environments to deploy.
+    type: list
+    elements: dict
+    required: true
+'''
+
+EXAMPLES = r'''
+- name: Bulk deployment trigger by environment id.
+  lagoon.api.deploy_bulk:
+    name: Trigger by Ansible
+    environments:
+      - id: environment_id
+    build_vars:
+      - name: build_var_name
+        value: build_var_value
+
+- name: Bulk deployment trigger by project & env name.
+  lagoon.api.deploy_bulk:
+    name: Trigger by Ansible
+    environments:
+      - name: environment_name
+        project:
+          name: project_name
+    build_vars:
+      - name: build_var_name
+        value: build_var_value
+'''

--- a/api/plugins/modules/env_variable.py
+++ b/api/plugins/modules/env_variable.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r'''
+module: env_variable
+short_description: Manage variables for a project or environment
+description:
+    - Manages variables for a project or environment.
+options:
+  name:
+    description:
+      - The name of the variable.
+    required: true
+    type: str
+  type:
+    description:
+      - The resource for the variable (project or environment).
+    required: true
+    type: str
+    choices: [ PROJECT, ENVIRONMENT ]
+  type_name:
+    description:
+      - The name of the resource for the variable.
+      - Name of the project or environment.
+    required: true
+    type: str
+  state:
+    description:
+      - Message to display to users before shutdown.
+    type: str
+    default: present
+    choices: [ absent, present ]
+  value:
+    description:
+      - The variable value.
+      - Required when state is present.
+    type: str
+  scope:
+    description:
+      - The variable scope.
+      - Required when state is present.
+    type: str
+    choices: [ BUILD, RUNTIME, GLOBAL, CONTAINER_REGISTRY, INTERNAL_CONTAINER_REGISTRY ]
+  replace_existing:
+    description:
+      - Specify whether to replace existing values.
+      - When this is true, an existing value for the variable will be deleted
+      - and recreated with the value specified.
+    type: bool
+    default: False
+'''
+
+EXAMPLES = r'''
+- name: Update Lagoon variable definition
+  lagoon.api.env_variable:
+    state: present
+    type: ENVIRONMENT
+    type_name: test-environment-master
+    name: foo
+    value: bar
+    replace_existing: true
+    scope: RUNTIME
+'''

--- a/api/plugins/modules/environment_delete.py
+++ b/api/plugins/modules/environment_delete.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r'''
+module: environment_delete
+short_description: Delete a project environment
+description:
+    - Deletes a project environment.
+options:
+  project:
+    description:
+      - The project name.
+    required: true
+    type: str
+  branch:
+    description:
+      - The project branch.
+    required: true
+    type: str
+'''
+
+EXAMPLES = r'''
+- name: Remove the Lagoon environment.
+  lagoon.api.environment_delete:
+    project: test-project
+    branch: temp-env
+'''

--- a/api/plugins/modules/environment_update.py
+++ b/api/plugins/modules/environment_update.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r'''
+module: environment_update
+short_description: Update a project environment's values
+description:
+    - Updates a project environment's values.
+options:
+  environment:
+    description:
+      - The project environment name.
+      - Required if environment_id not provided.
+    type: str
+  environment_id:
+    description:
+      - The project environment ID.
+      - Required if environment not provided.
+    type: int
+  values:
+    description:
+      - The environment values.
+    type: dict
+    default: None
+'''
+
+EXAMPLES = r'''
+- name: Set environment deployment cluster.
+  lagoon.api.environment_update:
+    environment: test-project-master
+    values:
+      kubernetes: 10
+'''

--- a/api/plugins/modules/fact.py
+++ b/api/plugins/modules/fact.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r'''
+module: fact
+short_description: Manage facts for an environment.
+description:
+    - Manages facts for an environment.
+options:
+  environment_id:
+    description:
+      - The ID of the environment.
+    required: true
+    type: int
+  name:
+    description:
+      - The name of the fact.
+    required: true
+    type: str
+  value:
+    description:
+      - The fact value.
+      - Required when state is present.
+    type: str
+  source:
+    description:
+      - The source of the fact.
+      - Required when state is present.
+    type: str
+  type:
+    description:
+      - The type of the fact.
+      - Required when state is present.
+    type: str
+    choices: [ TEXT, SEMVER, URL ]
+    required: true
+  state:
+    description:
+      - Message to display to users before shutdown.
+    type: str
+    default: present
+    choices: [ absent, present ]
+  description:
+    description:
+      - A description of the fact.
+      - Required when state is present.
+    type: str
+'''
+
+EXAMPLES = r'''
+- name: Add a fact to a Lagoon project
+  lagoon.api.fact:
+    environment: 1
+    name: php_version
+    value: 8.1.9
+    description: PHP version
+    type: SEMVER
+    category: fact
+    service: php
+'''

--- a/api/plugins/modules/info.py
+++ b/api/plugins/modules/info.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r'''
+module: info
+short_description: Fetches Lagoon resource information
+description:
+    - Fetches information for a Lagoon resource.
+options:
+  resource:
+    description:
+      - The resource type.
+    type: str
+    default: environment
+    choices: [ environment ]
+  name:
+    description:
+      - The resource name.
+    type: str
+    required: true
+'''
+
+EXAMPLES = r'''
+- name: Get an environment.
+  lagoon.api.info:
+    resource: environment
+    name: test-environment
+  register: env_info
+'''

--- a/api/plugins/modules/last_deploy.py
+++ b/api/plugins/modules/last_deploy.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r'''
+module: last_deploy
+short_description: Check the status of the last deployment
+description:
+    - Checks the status of the last deployment.
+options:
+  project:
+    description:
+      - The project name.
+    required: true
+    type: str
+  branch:
+    description:
+      - The project branch.
+    required: true
+    type: str
+  wait:
+    description:
+      - Wait for deployment completion before returning.
+    type: bool
+    default: False
+  delay:
+    description:
+      - Delay between checking deployment status when retrying.
+    type: int
+    default: 60
+  retries:
+    description:
+      - Number of times to check for deployment status before returning.
+    type: int
+    default: 30
+'''
+
+EXAMPLES = r'''
+- name: Trigger a deployment
+  lagoon.api.last_deploy:
+    project: test-project
+    branch: master
+    stagger: 5
+    retries: 60
+    wait: true
+'''

--- a/api/plugins/modules/metadata.py
+++ b/api/plugins/modules/metadata.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r'''
+module: metadata
+short_description: Manage a project's metadata
+description:
+    - Manages a project's metadata.
+options:
+  project_id:
+    description:
+      - The project's ID.
+    required: true
+    type: int
+  state:
+    description:
+      - Message to display to users before shutdown.
+    type: str
+    default: present
+    choices: [ absent, present ]
+  data:
+    description:
+      - The metadata values.
+    type: dict
+    default: None
+'''
+
+EXAMPLES = r'''
+- name: Add project metadata
+  lagoon.api.metadata:
+    state: present
+    data:
+      solr-version: 6
+    project_id: 7
+'''

--- a/api/plugins/modules/project_update.py
+++ b/api/plugins/modules/project_update.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r'''
+module: project_update
+short_description: Update the values for a project
+description:
+    - Updates the values for a project.
+options:
+  project:
+    description:
+      - The project's name.
+    required: true
+    type: str
+  values:
+    description:
+      - The project values.
+    type: dict
+    default: None
+'''
+
+EXAMPLES = r'''
+- name: Update project environment limit.
+  lagoon.api.project_update:
+    project: test-project
+    values:
+        developmentEnvironmentsLimit: 10
+'''


### PR DESCRIPTION
Not having the docs means ansible-lint fails for playbooks that use the action plugins.

Example of such a plugin in `community.general`:
- Action plugin: https://github.com/ansible-collections/community.general/blob/c4b18361b990fac683e0438a154eeac23b38d590/plugins/action/shutdown.py
- Module plugin with doc only: https://github.com/ansible-collections/community.general/blob/c4b18361b990fac683e0438a154eeac23b38d590/plugins/modules/shutdown.py

on-behalf-of: @govCMS <govcms@govcms.gov.au>