### PR TITLE
Add timeout support to the metadata action.

### DIFF
--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -23,7 +23,10 @@ class ActionModule(ActionBase):
         lagoon = ApiClient(
             task_vars.get('lagoon_api_endpoint'),
             task_vars.get('lagoon_api_token'),
-            {'headers': self._task.args.get('headers', {})}
+            {
+                'headers': self._task.args.get('headers', {}),
+                'timeout': self._task.args.get('timeout', 30)
+            }
         )
 
         state = self._task.args.get('state', 'present')


### PR DESCRIPTION
- Add support to provide a timeout override for the Lagoon API client via the metadata action

```
- name: Add project metadata
   lagoon.api.metadata:
      state: present
      data: "{{ config.metadata }}"
      project_id: "{{ project.id }}"
      timeout: 90
```