### PR TITLE
fix: added support for object metadata

### DIFF
--- a/api/plugins/module_utils/gqlMetadata.py
+++ b/api/plugins/module_utils/gqlMetadata.py
@@ -30,9 +30,13 @@ class Metadata(ResourceBase):
 
             for pName in project_names:
                 try:
-                    res[pName] = resources.get(
+                    metadata = resources.get(
                         self.sanitiseForQueryAlias(pName)).get(
                             'projectByName', {}).get('metadata', None)
+                    if isinstance(metadata, dict):
+                        res[pName] = metadata
+                    else:
+                        res[pName] = json.loads(metadata)
                 except:
                     res[pName] = None
         else:
@@ -49,7 +53,10 @@ class Metadata(ResourceBase):
                 return res
 
             for p in resources.get('allProjects'):
-                res[p['name']] = p['metadata']
+                if isinstance(p['metadata'], dict):
+                    res[p['name']] = p['metadata']
+                else:
+                    res[p['name']] = json.loads(p['metadata'])
 
         return res
 
@@ -82,7 +89,10 @@ class Metadata(ResourceBase):
         if not metadata_str:
             return f'{key}:null'
 
-        metadata = json.loads(metadata_str)
+        if isinstance(metadata_str, dict):
+            metadata = metadata_str
+        else:
+            metadata = json.loads(metadata_str)
         return f"{key}:{metadata.get(key, 'null')}"
 
     def remove(self, project_id: int, key: str) -> bool:


### PR DESCRIPTION
a recent update in the lagoon api turned metadata into an object rather than string