### PR TITLE
fix: use templar for legacy ApiClient inits

### DIFF
--- a/api/plugins/action/group.py
+++ b/api/plugins/action/group.py
@@ -17,8 +17,8 @@ class ActionModule(ActionBase):
         self._display.v("Task args: %s" % self._task.args)
 
         lagoon = ApiClient(
-            task_vars.get('lagoon_api_endpoint'),
-            task_vars.get('lagoon_api_token'),
+            self._templar.template(task_vars.get('lagoon_api_endpoint')).strip(),
+            self._templar.template(task_vars.get('lagoon_api_token')).strip(),
             {'headers': self._task.args.get('headers', {})}
         )
 

--- a/api/plugins/action/last_deploy.py
+++ b/api/plugins/action/last_deploy.py
@@ -15,8 +15,8 @@ class ActionModule(ActionBase):
         self._display.v("Task args: %s" % self._task.args)
 
         lagoon = ApiClient(
-            task_vars.get('lagoon_api_endpoint'),
-            task_vars.get('lagoon_api_token'),
+            self._templar.template(task_vars.get('lagoon_api_endpoint')).strip(),
+            self._templar.template(task_vars.get('lagoon_api_token')).strip(),
             {'headers': self._task.args.get('headers', {})}
         )
 

--- a/api/plugins/action/project_notification.py
+++ b/api/plugins/action/project_notification.py
@@ -16,8 +16,8 @@ class ActionModule(ActionBase):
         self._display.v("Task args: %s" % self._task.args)
 
         lagoon = ApiClient(
-            task_vars.get('lagoon_api_endpoint'),
-            task_vars.get('lagoon_api_token'),
+            self._templar.template(task_vars.get('lagoon_api_endpoint')).strip(),
+            self._templar.template(task_vars.get('lagoon_api_token')).strip(),
             {'headers': self._task.args.get('headers', {})}
         )
 

--- a/api/plugins/action/project_update.py
+++ b/api/plugins/action/project_update.py
@@ -25,8 +25,8 @@ class ActionModule(ActionBase):
             raise AnsibleError("No value to update.")
 
         lagoon = ApiClient(
-            task_vars.get('lagoon_api_endpoint'),
-            task_vars.get('lagoon_api_token'),
+            self._templar.template(task_vars.get('lagoon_api_endpoint')).strip(),
+            self._templar.template(task_vars.get('lagoon_api_token')).strip(),
             {'headers': self._task.args.get('headers', {})}
         )
 


### PR DESCRIPTION
When referencing a vault variable for the `lagoon_api_token`, e.g `lagoon_api_token: {{ vault_lagoon_api_token }}`, it would fail for a number of plugins using the legacy ApiClient since it would just be using `{{ vault_lagoon_api_token }}` as a literal value. Passing it via the templar ensures it resolves.

> [!NOTE]
> There is ongoing work to migrate all remaining plugins using the legacy ApiClient to the new GqlClient, which automatically passes the credentials through `templar`.