### PR TITLE
Replaces addEnvVariable mutation with addOrUpdateEnvVariableByName

### DIFF
--- a/api/plugins/action/env_variable.py
+++ b/api/plugins/action/env_variable.py
@@ -113,13 +113,9 @@ class ActionModule(LagoonActionBase):
                 result['id'] = existing_var['id']
                 return result
 
-            # Delete before recreating.
-            # lagoonVariable.delete(existing_var['id'])
-
         if state == 'absent':
             return result
 
-        # result['data'] = lagoonVariable.add(type, type_id, name, value, scope)
         result['data'] = lagoonVariable.addOrUpdateByName(lagoon_project_name, lagoon_environment_name, name, value, scope)
         self._display.v("Variable add result: %s" % result['data'])
 

--- a/api/plugins/action/list.py
+++ b/api/plugins/action/list.py
@@ -19,6 +19,8 @@ class ActionModule(LagoonActionBase):
 
     def run(self, tmp=None, task_vars=None):
 
+        self._display.v("Task args: %s" % self._task.args)
+
         if task_vars is None:
             task_vars = dict()
 

--- a/api/plugins/module_utils/gqlVariable.py
+++ b/api/plugins/module_utils/gqlVariable.py
@@ -44,6 +44,36 @@ class Variable(ResourceBase):
 
         return res
 
+    def addOrUpdateByName(self, projectName:str, environmentName: str, name:str, value:str, scope:str) -> dict:
+        res = self.client.execute_query(
+            """
+            mutation addOrUpdateEnvVariableByName(
+                $environment: String
+                $project: String!
+                $name: String!
+                $value: String!
+                $scope: EnvVariableScope!
+            ) {
+                addOrUpdateEnvVariableByName(input: {
+                    project: $project
+                    environment: $environment
+                    scope: $scope
+                    name: $name
+                    value: $value
+                }) {
+                    id
+                }
+            }""",
+            {
+                "environment": environmentName,
+                "project": projectName,
+                "scope": scope,
+                "name": name,
+                "value": str(value),
+            }
+        )
+        return res['addOrUpdateEnvVariableByName']
+
     def add(self, type: str, type_id: int, name: str, value: str, scope: str) -> dict:
         res = self.client.execute_query(
             """

--- a/api/plugins/module_utils/gqlVariable.py
+++ b/api/plugins/module_utils/gqlVariable.py
@@ -74,36 +74,6 @@ class Variable(ResourceBase):
         )
         return res['addOrUpdateEnvVariableByName']
 
-    def add(self, type: str, type_id: int, name: str, value: str, scope: str) -> dict:
-        res = self.client.execute_query(
-            """
-            mutation addEnvVariable(
-                $type: EnvVariableType!
-                $type_id: Int!
-                $name: String!
-                $value: String!
-                $scope: EnvVariableScope!
-            ) {
-                addEnvVariable(input: {
-                    type: $type
-                    typeId: $type_id
-                    scope: $scope
-                    name: $name
-                    value: $value
-                }) {
-                    id
-                }
-            }""",
-            {
-                "type": type,
-                "type_id": int(type_id),
-                "scope": scope,
-                "name": name,
-                "value": str(value),
-            }
-        )
-        return res['addEnvVariable']
-
     def delete(self, id: int) -> bool:
         res = self.client.execute_query(
             """

--- a/api/tests/unit/plugins/module_utils/test_gql_variable.py
+++ b/api/tests/unit/plugins/module_utils/test_gql_variable.py
@@ -10,18 +10,18 @@ sys.modules['ansible.utils.display'] = unittest.mock.Mock()
 
 class GqlVariableTester(unittest.TestCase):
 
-    def test_add(self):
+    def test_variable_addOrUpdateByName(self):
         client = GqlClient('foo', 'bar')
         client.execute_query = MagicMock()
 
         lagoonVariable = Variable(client)
-        lagoonVariable.add('PROJECT', 1, 'SOME_VAR', 'foo', 'RUNTIME')
+        lagoonVariable.addOrUpdateByName('projectname', "environmentname", 'SOME_VAR', 'foo', 'RUNTIME')
         _, query_args = client.execute_query.call_args.args
 
-        assert isinstance(query_args['type'], str)
-        assert query_args['type'] == 'PROJECT'
-        assert isinstance(query_args['type_id'], int)
-        assert query_args['type_id'] == 1
+        assert isinstance(query_args['project'], str)
+        assert query_args['project'] == 'projectname'
+        assert isinstance(query_args['environment'], str)
+        assert query_args['environment'] == 'environmentname'
         assert isinstance(query_args['scope'], str)
         assert query_args['scope'] == 'RUNTIME'
         assert isinstance(query_args['name'], str)
@@ -35,12 +35,12 @@ class GqlVariableTester(unittest.TestCase):
 
         lagoonVariable = Variable(client)
 
-        lagoonVariable.add('PROJECT', 1, 'SOME_VAR', True, 'RUNTIME')
+        lagoonVariable.addOrUpdateByName('projectname', "environmentname", 'SOME_VAR', True, 'RUNTIME')
         _, query_args = client.execute_query.call_args.args
         assert isinstance(query_args['value'], str)
         assert query_args['value'] == 'True'
 
-        lagoonVariable.add('PROJECT', 1, 'SOME_VAR2', 50, 'RUNTIME')
+        lagoonVariable.addOrUpdateByName('projectname', "environmentname", 'SOME_VAR2', 50, 'RUNTIME')
         _, query_args = client.execute_query.call_args.args
         assert isinstance(query_args['value'], str)
         assert query_args['value'] == '50'


### PR DESCRIPTION
closes #70 

This replaces the deprecated call to the deprecated `addEnvVariable` mutation with `addOrUpdateEnvVariableByName`