### PR TITLE
Feature/update deploytargetconfig task

### DIFF
--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -34,7 +34,6 @@ class ActionModule(LagoonActionBase):
             if state == "present":
                 specified_branch_patterns = [config['branches'] for config in configs]
                 existing_config_ids = [config['id'] for config in project["deployTargetConfigs"]]
-                specified_config_ids = []
                 changes = determine_required_updates(
                     project["deployTargetConfigs"],
                     configs,

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -60,6 +60,7 @@ class ActionModule(LagoonActionBase):
                             config['failed'] = True
                         result['result'].append(config)
                     result['changed'] = True
+                # Cleanup code for deploytargetconfig when replace == true 
                 if replace:
                     for existing_config in project["deployTargetConfigs"]:
                         if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -45,6 +45,13 @@ class ActionModule(LagoonActionBase):
                             self._display.vvvv(f"deleting config {config}")
                             DeployTargetConfig(self.client).delete(
                                 project['id'], config['_existing_id'])
+                            #Added deploytargetconfig cleanup 
+                            for existing_config in project["deployTargetConfigs"]:
+                                if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
+                                    self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
+                                    if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
+                                        result['result'].append({'id': existing_config['id'], 'deleted': True})
+                                        result['changed'] = True
 
                         self._display.vvvv(f"adding config {config}")
                         addResult = DeployTargetConfig(self.client).add(
@@ -59,14 +66,8 @@ class ActionModule(LagoonActionBase):
                         else:
                             config['failed'] = True
                         result['result'].append(config)
-                        result['changed'] = True
-                        #Added deploytargetconfig cleanup 
-                        for existing_config in project["deployTargetConfigs"]:
-                            if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
-                                self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
-                                if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
-                                    result['result'].append({'id': existing_config['id'], 'deleted': True})
-                                    result['changed'] = True
+                    result['changed'] = True
+
 
             elif state == "absent":
                 result['changed'] = False

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -32,6 +32,8 @@ class ActionModule(LagoonActionBase):
 
         for project in lagoonProject.projects:
             if state == "present":
+                existing_config_ids = [config['id'] for config in project["deployTargetConfigs"]]
+                specified_config_ids = []
                 changes = determine_required_updates(
                     project["deployTargetConfigs"],
                     configs,
@@ -58,12 +60,13 @@ class ActionModule(LagoonActionBase):
                             config['failed'] = True
                         result['result'].append(config)
                     result['changed'] = True
-                for existing_config in existing_configs:
-                    if existing_config['id'] not in specified_ids:
-                        self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
-                        if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
-                            result['result'].append({'id': existing_config['id'], 'deleted': True})
+                for config_id in existing_config_ids:
+                    if config_id not in specified_config_ids:
+                        self._display.vvvv(f"Deleting unmatched config with ID {config_id}")
+                        if DeployTargetConfig(self.client).delete(project['id'], config_id):
+                            result['result'].append({'id': config_id, 'deleted': True})
                             result['changed'] = True
+
             elif state == "absent":
                 result['changed'] = False
                 for c in project["deployTargetConfigs"]:

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -59,13 +59,14 @@ class ActionModule(LagoonActionBase):
                         else:
                             config['failed'] = True
                         result['result'].append(config)
-                    result['changed'] = True
-                for existing_config in project["deployTargetConfigs"]:
-                    if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
-                        self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
-                        if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
-                            result['result'].append({'id': existing_config['id'], 'deleted': True})
-                            result['changed'] = True
+                        result['changed'] = True
+                        #Added deploytargetconfig cleanup 
+                        for existing_config in project["deployTargetConfigs"]:
+                            if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
+                                self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
+                                if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
+                                    result['result'].append({'id': existing_config['id'], 'deleted': True})
+                                    result['changed'] = True
 
             elif state == "absent":
                 result['changed'] = False

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -60,12 +60,13 @@ class ActionModule(LagoonActionBase):
                             config['failed'] = True
                         result['result'].append(config)
                     result['changed'] = True
-                for existing_config in project["deployTargetConfigs"]:
-                    if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
-                        self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
-                        if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
-                            result['result'].append({'id': existing_config['id'], 'deleted': True})
-                            result['changed'] = True
+                if replace:
+                    for existing_config in project["deployTargetConfigs"]:
+                        if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
+                            self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
+                            if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
+                                result['result'].append({'id': existing_config['id'], 'deleted': True})
+                                result['changed'] = True
 
             elif state == "absent":
                 result['changed'] = False

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -58,6 +58,12 @@ class ActionModule(LagoonActionBase):
                             config['failed'] = True
                         result['result'].append(config)
                     result['changed'] = True
+                for existing_config in existing_configs:
+                    if existing_config['id'] not in specified_ids:
+                        self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
+                        if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
+                            result['result'].append({'id': existing_config['id'], 'deleted': True})
+                            result['changed'] = True
             elif state == "absent":
                 result['changed'] = False
                 for c in project["deployTargetConfigs"]:

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -32,6 +32,7 @@ class ActionModule(LagoonActionBase):
 
         for project in lagoonProject.projects:
             if state == "present":
+                specified_branch_patterns = [config['branches'] for config in configs]
                 existing_config_ids = [config['id'] for config in project["deployTargetConfigs"]]
                 specified_config_ids = []
                 changes = determine_required_updates(
@@ -60,11 +61,11 @@ class ActionModule(LagoonActionBase):
                             config['failed'] = True
                         result['result'].append(config)
                     result['changed'] = True
-                for config_id in existing_config_ids:
-                    if config_id not in specified_config_ids:
-                        self._display.vvvv(f"Deleting unmatched config with ID {config_id}")
-                        if DeployTargetConfig(self.client).delete(project['id'], config_id):
-                            result['result'].append({'id': config_id, 'deleted': True})
+                for existing_config in project["deployTargetConfigs"]:
+                    if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
+                        self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
+                        if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
+                            result['result'].append({'id': existing_config['id'], 'deleted': True})
                             result['changed'] = True
 
             elif state == "absent":

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -45,13 +45,6 @@ class ActionModule(LagoonActionBase):
                             self._display.vvvv(f"deleting config {config}")
                             DeployTargetConfig(self.client).delete(
                                 project['id'], config['_existing_id'])
-                            #Added deploytargetconfig cleanup 
-                            for existing_config in project["deployTargetConfigs"]:
-                                if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
-                                    self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
-                                    if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
-                                        result['result'].append({'id': existing_config['id'], 'deleted': True})
-                                        result['changed'] = True
 
                         self._display.vvvv(f"adding config {config}")
                         addResult = DeployTargetConfig(self.client).add(
@@ -67,7 +60,12 @@ class ActionModule(LagoonActionBase):
                             config['failed'] = True
                         result['result'].append(config)
                     result['changed'] = True
-
+                for existing_config in project["deployTargetConfigs"]:
+                    if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
+                        self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
+                        if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
+                            result['result'].append({'id': existing_config['id'], 'deleted': True})
+                            result['changed'] = True
 
             elif state == "absent":
                 result['changed'] = False


### PR DESCRIPTION
Previously, if a config had new branch pattern in config this did not delete the old deployment target configs. 
This PR includes the logic cleanup code for deploytargetconfig when replace == true. 
