### PR TITLE
Feature/update deploytargetconfig task

### DIFF
--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -34,7 +34,6 @@ class ActionModule(LagoonActionBase):
             if state == "present":
                 specified_branch_patterns = [config['branches'] for config in configs]
                 existing_config_ids = [config['id'] for config in project["deployTargetConfigs"]]
-                specified_config_ids = []
                 changes = determine_required_updates(
                     project["deployTargetConfigs"],
                     configs,

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -60,6 +60,7 @@ class ActionModule(LagoonActionBase):
                             config['failed'] = True
                         result['result'].append(config)
                     result['changed'] = True
+                # Cleanup code for deploytargetconfig when replace == true 
                 if replace:
                     for existing_config in project["deployTargetConfigs"]:
                         if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -45,6 +45,13 @@ class ActionModule(LagoonActionBase):
                             self._display.vvvv(f"deleting config {config}")
                             DeployTargetConfig(self.client).delete(
                                 project['id'], config['_existing_id'])
+                            #Added deploytargetconfig cleanup 
+                            for existing_config in project["deployTargetConfigs"]:
+                                if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
+                                    self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
+                                    if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
+                                        result['result'].append({'id': existing_config['id'], 'deleted': True})
+                                        result['changed'] = True
 
                         self._display.vvvv(f"adding config {config}")
                         addResult = DeployTargetConfig(self.client).add(
@@ -59,14 +66,8 @@ class ActionModule(LagoonActionBase):
                         else:
                             config['failed'] = True
                         result['result'].append(config)
-                        result['changed'] = True
-                        #Added deploytargetconfig cleanup 
-                        for existing_config in project["deployTargetConfigs"]:
-                            if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
-                                self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
-                                if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
-                                    result['result'].append({'id': existing_config['id'], 'deleted': True})
-                                    result['changed'] = True
+                    result['changed'] = True
+
 
             elif state == "absent":
                 result['changed'] = False

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -121,10 +121,4 @@ def determine_required_updates(existing_configs, desired_configs):
         if not found or not uptodate:
             addition_required.append(desired)
 
-    # Filter out additions for configs already marked for deletion
-    additions_filtered = [
-        config for config in addition_required
-        if config.get('_existing_id') not in deletion_required
-    ]
-
-    return additions_filtered, deletion_required
+    return addition_required, deletion_required

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -35,7 +35,7 @@ class ActionModule(LagoonActionBase):
                 addition_required, deletion_required = determine_required_updates(
                     project["deployTargetConfigs"],
                     configs,
-                )            
+                )
                 result['changed'] = False
 
                 # Handle deletions for deletion_required IDs
@@ -109,7 +109,6 @@ def determine_required_updates(existing_configs, desired_configs):
 
             desired['_existing_id'] = existing_config['id']
             found = True
-            print("Found a match based on branches. Appended _existing_id:", desired) # checking desired
 
             # Mark for update (or in this context, addition) if there are discrepancies in any key property
             if (existing_config['pullrequests'] != desired['pullrequests'] or
@@ -117,20 +116,15 @@ def determine_required_updates(existing_configs, desired_configs):
                     str(existing_config['weight']) != str(desired['weight'])):
                 desired['_existing_id'] = existing_config['id']
                 uptodate = False
-                print("Discrepancy found. Marked as not up-to-date:", desired)
                 break
 
         if not found or not uptodate:
             addition_required.append(desired)
-            print("Added to addition_required:", desired) # checking desired 
 
     # Filter out additions for configs already marked for deletion
     additions_filtered = [
         config for config in addition_required
         if config.get('_existing_id') not in deletion_required
     ]
-
-    print("Final additions_filtered:", additions_filtered) # checking final addititions filtered
-    print("deletion_required:", deletion_required)  # checking final deletion required
 
     return additions_filtered, deletion_required

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -32,6 +32,8 @@ class ActionModule(LagoonActionBase):
 
         for project in lagoonProject.projects:
             if state == "present":
+                existing_config_ids = [config['id'] for config in project["deployTargetConfigs"]]
+                specified_config_ids = []
                 changes = determine_required_updates(
                     project["deployTargetConfigs"],
                     configs,
@@ -58,12 +60,13 @@ class ActionModule(LagoonActionBase):
                             config['failed'] = True
                         result['result'].append(config)
                     result['changed'] = True
-                for existing_config in existing_configs:
-                    if existing_config['id'] not in specified_ids:
-                        self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
-                        if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
-                            result['result'].append({'id': existing_config['id'], 'deleted': True})
+                for config_id in existing_config_ids:
+                    if config_id not in specified_config_ids:
+                        self._display.vvvv(f"Deleting unmatched config with ID {config_id}")
+                        if DeployTargetConfig(self.client).delete(project['id'], config_id):
+                            result['result'].append({'id': config_id, 'deleted': True})
                             result['changed'] = True
+
             elif state == "absent":
                 result['changed'] = False
                 for c in project["deployTargetConfigs"]:

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -109,6 +109,7 @@ def determine_required_updates(existing_configs, desired_configs):
 
             desired['_existing_id'] = existing_config['id']
             found = True
+            print("Found a match based on branches. Appended _existing_id:", desired) # checking desired
 
             # Mark for update (or in this context, addition) if there are discrepancies in any key property
             if (existing_config['pullrequests'] != desired['pullrequests'] or
@@ -116,15 +117,20 @@ def determine_required_updates(existing_configs, desired_configs):
                     str(existing_config['weight']) != str(desired['weight'])):
                 desired['_existing_id'] = existing_config['id']
                 uptodate = False
+                print("Discrepancy found. Marked as not up-to-date:", desired)
                 break
 
         if not found or not uptodate:
             addition_required.append(desired)
+            print("Added to addition_required:", desired) # checking desired 
 
     # Filter out additions for configs already marked for deletion
     additions_filtered = [
         config for config in addition_required
         if config.get('_existing_id') not in deletion_required
     ]
+
+    print("Final additions_filtered:", additions_filtered) # checking final addititions filtered
+    print("deletion_required:", deletion_required)  # checking final deletion required
 
     return additions_filtered, deletion_required

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -59,13 +59,14 @@ class ActionModule(LagoonActionBase):
                         else:
                             config['failed'] = True
                         result['result'].append(config)
-                    result['changed'] = True
-                for existing_config in project["deployTargetConfigs"]:
-                    if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
-                        self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
-                        if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
-                            result['result'].append({'id': existing_config['id'], 'deleted': True})
-                            result['changed'] = True
+                        result['changed'] = True
+                        #Added deploytargetconfig cleanup 
+                        for existing_config in project["deployTargetConfigs"]:
+                            if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
+                                self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
+                                if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
+                                    result['result'].append({'id': existing_config['id'], 'deleted': True})
+                                    result['changed'] = True
 
             elif state == "absent":
                 result['changed'] = False

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -60,12 +60,13 @@ class ActionModule(LagoonActionBase):
                             config['failed'] = True
                         result['result'].append(config)
                     result['changed'] = True
-                for existing_config in project["deployTargetConfigs"]:
-                    if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
-                        self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
-                        if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
-                            result['result'].append({'id': existing_config['id'], 'deleted': True})
-                            result['changed'] = True
+                if replace:
+                    for existing_config in project["deployTargetConfigs"]:
+                        if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
+                            self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
+                            if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
+                                result['result'].append({'id': existing_config['id'], 'deleted': True})
+                                result['changed'] = True
 
             elif state == "absent":
                 result['changed'] = False

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -58,6 +58,12 @@ class ActionModule(LagoonActionBase):
                             config['failed'] = True
                         result['result'].append(config)
                     result['changed'] = True
+                for existing_config in existing_configs:
+                    if existing_config['id'] not in specified_ids:
+                        self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
+                        if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
+                            result['result'].append({'id': existing_config['id'], 'deleted': True})
+                            result['changed'] = True
             elif state == "absent":
                 result['changed'] = False
                 for c in project["deployTargetConfigs"]:

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -32,6 +32,7 @@ class ActionModule(LagoonActionBase):
 
         for project in lagoonProject.projects:
             if state == "present":
+                specified_branch_patterns = [config['branches'] for config in configs]
                 existing_config_ids = [config['id'] for config in project["deployTargetConfigs"]]
                 specified_config_ids = []
                 changes = determine_required_updates(
@@ -60,11 +61,11 @@ class ActionModule(LagoonActionBase):
                             config['failed'] = True
                         result['result'].append(config)
                     result['changed'] = True
-                for config_id in existing_config_ids:
-                    if config_id not in specified_config_ids:
-                        self._display.vvvv(f"Deleting unmatched config with ID {config_id}")
-                        if DeployTargetConfig(self.client).delete(project['id'], config_id):
-                            result['result'].append({'id': config_id, 'deleted': True})
+                for existing_config in project["deployTargetConfigs"]:
+                    if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
+                        self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
+                        if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
+                            result['result'].append({'id': existing_config['id'], 'deleted': True})
                             result['changed'] = True
 
             elif state == "absent":

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -45,13 +45,6 @@ class ActionModule(LagoonActionBase):
                             self._display.vvvv(f"deleting config {config}")
                             DeployTargetConfig(self.client).delete(
                                 project['id'], config['_existing_id'])
-                            #Added deploytargetconfig cleanup 
-                            for existing_config in project["deployTargetConfigs"]:
-                                if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
-                                    self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
-                                    if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
-                                        result['result'].append({'id': existing_config['id'], 'deleted': True})
-                                        result['changed'] = True
 
                         self._display.vvvv(f"adding config {config}")
                         addResult = DeployTargetConfig(self.client).add(
@@ -67,7 +60,12 @@ class ActionModule(LagoonActionBase):
                             config['failed'] = True
                         result['result'].append(config)
                     result['changed'] = True
-
+                for existing_config in project["deployTargetConfigs"]:
+                    if existing_config['id'] in existing_config_ids and existing_config['branches'] not in specified_branch_patterns:
+                        self._display.vvvv(f"Deleting unmatched config with ID {existing_config['id']}")
+                        if DeployTargetConfig(self.client).delete(project['id'], existing_config['id']):
+                            result['result'].append({'id': existing_config['id'], 'deleted': True})
+                            result['changed'] = True
 
             elif state == "absent":
                 result['changed'] = False

--- a/api/tests/unit/plugins/action/test_determine_updates_required.py
+++ b/api/tests/unit/plugins/action/test_determine_updates_required.py
@@ -18,11 +18,11 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
         
-        additions_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
         
-        assert len(additions_required) == 1, "Expected one addition required"
-        assert additions_required[0]['branches'] == '^(main)$', "Expected branches to match ^(main)$"
-        assert additions_required[0]['deployTarget'] == 1, "Expected deployTarget to be 1"
+        assert len(addition_required) == 1, "Expected one addition required"
+        assert addition_required[0]['branches'] == '^(main)$', "Expected branches to match ^(main)$"
+        assert addition_required[0]['deployTarget'] == 1, "Expected deployTarget to be 1"
         assert len(deletion_required) == 0, "Expected no deletions required"
 
     def test_update_not_required(self):
@@ -44,9 +44,9 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        additions_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(additions_required) == 0, "Expected no additions required"
+        assert len(addition_required) == 0, "Expected no additions required"
         assert len(deletion_required) == 0, "Expected no deletions required"
 
     def test_update_required_weight(self):
@@ -68,10 +68,10 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        additions_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(additions_required) == 1, "Expected one addition required due to weight change"
-        assert additions_required[0]['weight'] == 2, "Expected weight to be updated to 2"
+        assert len(addition_required) == 1, "Expected one addition required due to weight change"
+        assert addition_required[0]['weight'] == 2, "Expected weight to be updated to 2"
         assert len(deletion_required) == 0, "Expected no deletions required"
 
     def test_update_required_cluster(self):
@@ -93,10 +93,10 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        additions_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(additions_required) == 1, "Expected one addition required due to deployTarget change"
-        assert additions_required[0]['deployTarget'] == 2, "Expected deployTarget to be updated to 2"
+        assert len(addition_required) == 1, "Expected one addition required due to deployTarget change"
+        assert addition_required[0]['deployTarget'] == 2, "Expected deployTarget to be updated to 2"
         assert len(deletion_required) == 0, "Expected no deletions required"
 
     def test_orphan_existing(self):
@@ -131,9 +131,9 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ] 
 
-        additions_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(additions_required) == 2, "Expected two additions required due to changes"
-        assert additions_required[0]['deployTarget'] == 1, "Expected the first addition to have deployTarget 1"
-        assert additions_required[1]['deployTarget'] == 2, "Expected the second addition to have deployTarget 2"
+        assert len(addition_required) == 2, "Expected two additions required due to changes"
+        assert addition_required[0]['deployTarget'] == 1, "Expected the first addition to have deployTarget 1"
+        assert addition_required[1]['deployTarget'] == 2, "Expected the second addition to have deployTarget 2"
         assert len(deletion_required) == 2, "Expecting 2 deletion of orphan deploytarget config"

--- a/api/tests/unit/plugins/action/test_determine_updates_required.py
+++ b/api/tests/unit/plugins/action/test_determine_updates_required.py
@@ -18,11 +18,12 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
         
-        updates_required = determine_required_updates(existing_configs, desired_configs)
+        additions_filtered, deletion_required = determine_required_updates(existing_configs, desired_configs)
         
-        assert len(updates_required) == 1
-        assert updates_required[0]['branches'] == '^(main)$'
-        assert updates_required[0]['deployTarget'] == 1
+        assert len(additions_filtered) == 1, "Expected one addition required"
+        assert additions_filtered[0]['branches'] == '^(main)$', "Expected branches to match ^(main)$"
+        assert additions_filtered[0]['deployTarget'] == 1, "Expected deployTarget to be 1"
+        assert len(deletion_required) == 0, "Expected no deletions required"
 
     def test_update_not_required(self):
         existing_configs = [
@@ -43,9 +44,10 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        updates_required = determine_required_updates(existing_configs, desired_configs)
+        additions_filtered, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(updates_required) == 0
+        assert len(additions_filtered) == 0, "Expected no additions required"
+        assert len(deletion_required) == 0, "Expected no deletions required"
 
     def test_update_required_weight(self):
         existing_configs = [
@@ -66,10 +68,11 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        updates_required = determine_required_updates(existing_configs, desired_configs)
+        additions_filtered, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(updates_required) == 1
-        assert updates_required[0]['weight'] == 2
+        assert len(additions_filtered) == 1, "Expected one addition required due to weight change"
+        assert additions_filtered[0]['weight'] == 2, "Expected weight to be updated to 2"
+        assert len(deletion_required) == 0, "Expected no deletions required"
 
     def test_update_required_cluster(self):
         existing_configs = [
@@ -90,10 +93,11 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        updates_required = determine_required_updates(existing_configs, desired_configs)
+        additions_filtered, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(updates_required) == 1
-        assert updates_required[0]['deployTarget'] == 2
+        assert len(additions_filtered) == 1, "Expected one addition required due to deployTarget change"
+        assert additions_filtered[0]['deployTarget'] == 2, "Expected deployTarget to be updated to 2"
+        assert len(deletion_required) == 0, "Expected no deletions required"
 
     def test_orphan_existing(self):
         existing_configs = [
@@ -114,14 +118,22 @@ class DetermineUpdatesTester(unittest.TestCase):
         ]
         desired_configs = [
             {
-                'branches': '^(main)$',
+                'branches': '^(production|standby)$',
+                'deployTarget': 1,
+                'pullrequests': 'false',
+                'weight': 1
+            },
+            {
+                'branches': '^(develop|master)$',
                 'deployTarget': 2,
                 'pullrequests': 'true',
                 'weight': 1
             }
         ] 
 
-        updates_required = determine_required_updates(existing_configs, desired_configs)
+        additions_filtered, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(updates_required) == 1
-        assert updates_required[0]['deployTarget'] == 2
+        assert len(additions_filtered) == 2, "Expected two additions required due to changes"
+        assert additions_filtered[0]['deployTarget'] == 1, "Expected the first addition to have deployTarget 1"
+        assert additions_filtered[1]['deployTarget'] == 2, "Expected the second addition to have deployTarget 2"
+        assert len(deletion_required) == 2, "Expecting 2 deletion of orphan deploytarget config"

--- a/api/tests/unit/plugins/action/test_determine_updates_required.py
+++ b/api/tests/unit/plugins/action/test_determine_updates_required.py
@@ -18,11 +18,11 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
         
-        additions_filtered, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        additions_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
         
-        assert len(additions_filtered) == 1, "Expected one addition required"
-        assert additions_filtered[0]['branches'] == '^(main)$', "Expected branches to match ^(main)$"
-        assert additions_filtered[0]['deployTarget'] == 1, "Expected deployTarget to be 1"
+        assert len(additions_required) == 1, "Expected one addition required"
+        assert additions_required[0]['branches'] == '^(main)$', "Expected branches to match ^(main)$"
+        assert additions_required[0]['deployTarget'] == 1, "Expected deployTarget to be 1"
         assert len(deletion_required) == 0, "Expected no deletions required"
 
     def test_update_not_required(self):
@@ -44,9 +44,9 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        additions_filtered, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        additions_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(additions_filtered) == 0, "Expected no additions required"
+        assert len(additions_required) == 0, "Expected no additions required"
         assert len(deletion_required) == 0, "Expected no deletions required"
 
     def test_update_required_weight(self):
@@ -68,10 +68,10 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        additions_filtered, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        additions_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(additions_filtered) == 1, "Expected one addition required due to weight change"
-        assert additions_filtered[0]['weight'] == 2, "Expected weight to be updated to 2"
+        assert len(additions_required) == 1, "Expected one addition required due to weight change"
+        assert additions_required[0]['weight'] == 2, "Expected weight to be updated to 2"
         assert len(deletion_required) == 0, "Expected no deletions required"
 
     def test_update_required_cluster(self):
@@ -93,10 +93,10 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        additions_filtered, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        additions_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(additions_filtered) == 1, "Expected one addition required due to deployTarget change"
-        assert additions_filtered[0]['deployTarget'] == 2, "Expected deployTarget to be updated to 2"
+        assert len(additions_required) == 1, "Expected one addition required due to deployTarget change"
+        assert additions_required[0]['deployTarget'] == 2, "Expected deployTarget to be updated to 2"
         assert len(deletion_required) == 0, "Expected no deletions required"
 
     def test_orphan_existing(self):
@@ -131,9 +131,9 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ] 
 
-        additions_filtered, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        additions_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(additions_filtered) == 2, "Expected two additions required due to changes"
-        assert additions_filtered[0]['deployTarget'] == 1, "Expected the first addition to have deployTarget 1"
-        assert additions_filtered[1]['deployTarget'] == 2, "Expected the second addition to have deployTarget 2"
+        assert len(additions_required) == 2, "Expected two additions required due to changes"
+        assert additions_required[0]['deployTarget'] == 1, "Expected the first addition to have deployTarget 1"
+        assert additions_required[1]['deployTarget'] == 2, "Expected the second addition to have deployTarget 2"
         assert len(deletion_required) == 2, "Expecting 2 deletion of orphan deploytarget config"


### PR DESCRIPTION
As previously, any update in config related to weight, pull-request and deploytarget ID, the id was deleted and then recreated as a update process for deploy target config. However, this wasn't the case for any updated branch in config which added new deploy target config but did not delete the previous deploy target config IDs. 

I have now added additional logic for `deletion_required ` which checks if there is any branch from existing config that does not match the desired config should be in deletion_required. 

Also, the unit testing file for deploytargetconfig is updated. 