### PR TITLE
Feature/fix reporting in add metadata task

### DIFF
--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -21,46 +21,35 @@ class ActionModule(LagoonActionBase):
         project_id = int(self._task.args.get('project_id', None))
         project_name = self._task.args.get('project_name', None)
 
-        print(f"rmk-debug: State={state}, Project ID={project_id}, Project Name={project_name}")
-
         result = {'result': [], 'invalid': [], 'changed': False, 'failed': False}
 
         if not isinstance(data, (dict, list)):
             result['failed'] = True
             result['message'] = 'Invalid data type; expected Dict or List'
-            print("rmk-debug: Invalid data type provided.")
             return result
 
         try:
             if project_name:
                 project_instance = Project(self.client).byName(project_name, ['metadata'])
-                print(f"rmk-debug: project_instance details: {project_instance}")
                 current_metadata = project_instance.projects[0]['metadata'] if project_instance.projects else {}
-                print(f"rmk-debug: current_metadata: {current_metadata}")
-                print(f"rmk-debug: Fetched current metadata for project '{project_name}'.")
             else:
                 current_metadata = {}  # Assuming no project name means no current metadata
-                print("rmk-debug: No project name provided, proceeding without current metadata.")
         except Exception as e:
             result['failed'] = True
             result['message'] = f"Error fetching project metadata: {e}"
-            print(f"rmk-debug: Exception caught while fetching project metadata: {e}")
             return result
 
         lagoonMetadata = Metadata(self.client)
 
         def is_change_required(key, value):
             required = current_metadata.get(key) != value
-            print(f"rmk-debug: Change required for '{key}'? {required}")
             return required
 
         if state == 'present':
-            print("rmk-debug: Processing state 'present'.")
             if isinstance(data, list):
                 for item in data:
                     if not isinstance(item, dict) or 'key' not in item or 'value' not in item:
                         result['invalid'].append(item)
-                        print(f"rmk-debug: Invalid item skipped: {item}")
                         continue
                     key, value = item['key'], item['value']
                     if is_change_required(key, value):
@@ -68,10 +57,8 @@ class ActionModule(LagoonActionBase):
                             update_result = lagoonMetadata.update(project_id, key, value)
                             result['result'].append({key: value})
                             result['changed'] = True
-                            print(f"rmk-debug: Updated metadata list for key '{key}' with value '{value}'.")
                         except Exception as e:
                             result['invalid'].append(key)
-                            print(f"rmk-debug: Exception caught list while updating '{key}': {e}")
             else:  # if data is a dict
                 for key, value in data.items():
                     if is_change_required(key, value):
@@ -79,13 +66,10 @@ class ActionModule(LagoonActionBase):
                             update_result = lagoonMetadata.update(project_id, key, value)
                             result['result'].append({key: value})
                             result['changed'] = True
-                            print(f"rmk-debug: Updated metadata for key '{key}' with value '{value}'.")
                         except Exception as e:
                             result['invalid'].append(key)
-                            print(f"rmk-debug: Exception caught while updating '{key}': {e}")
 
         elif state == 'absent':
-            print("rmk-debug: Processing state 'absent'.")
             # handle both list and dictionaries
             if isinstance(data, list):
                 keys_to_remove = []
@@ -97,7 +81,6 @@ class ActionModule(LagoonActionBase):
             else:
                 keys_to_remove = list(data.keys())
 
-            print("rmk-debug: Keys to remove -- ", keys_to_remove)
 
             for key in keys_to_remove:
                 if key in current_metadata:
@@ -105,18 +88,11 @@ class ActionModule(LagoonActionBase):
                         remove_result = lagoonMetadata.remove(project_id, key)
                         result['result'].append({key: 'removed'})
                         result['changed'] = True
-                        print(f"rmk-debug: Removed metadata for key '{key}'.")
                     except Exception as e:
                         result['invalid'].append(key)
-                        print(f"rmk-debug: Exception caught while removing '{key}': {e}")
-
-
-
 
         if result['invalid']:
             result['failed'] = True
             result['message'] = f"Errors occurred with keys: {', '.join(result['invalid'])}"
-            print(f"rmk-debug: Operation completed with errors: {result['invalid']}")
 
-        print(f"rmk-debug: Final result: {result}")
         return result

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -86,8 +86,11 @@ class ActionModule(LagoonActionBase):
 
         elif state == 'absent':
             print("rmk-debug: Processing state 'absent'.")
-            keys_to_remove = [item['key'] for item in data]
+            keys_to_remove = [k if isinstance(data, list) else k for k in (data if isinstance(data, list) else data.keys())]
             for key in keys_to_remove:
+                if isinstance(key, dict):  # Handle unexpected dictionary
+                    print(f"rmk-debug: Skipping unexpected dict in keys_to_remove: {key}")
+                    continue  # Skip or handle dictionaries differently
                 if key in current_metadata:
                     try:
                         remove_result = lagoonMetadata.remove(project_id, key)
@@ -97,6 +100,7 @@ class ActionModule(LagoonActionBase):
                     except Exception as e:
                         result['invalid'].append(key)
                         print(f"rmk-debug: Exception caught while removing '{key}': {e}")
+
 
 
         if result['invalid']:

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -34,7 +34,9 @@ class ActionModule(LagoonActionBase):
         try:
             if project_name:
                 project_instance = Project(self.client).byName(project_name, ['metadata'])
+                print(f"rmk-debug: project_instance details: {project_instance}")
                 current_metadata = project_instance.projects[0]['metadata'] if project_instance.projects else {}
+                print(f"rmk-debug: current_metadata: {current_metadata}")
                 print(f"rmk-debug: Fetched current metadata for project '{project_name}'.")
             else:
                 current_metadata = {}  # Assuming no project name means no current metadata

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -4,7 +4,7 @@ from ..module_utils.gqlProject import Project
 import json
 
 class ActionModule(LagoonActionBase):
-    ''' Perform comparisons on dictionary objects '''
+    '''Perform comparisons on dictionary objects and update metadata accordingly.'''
 
     def run(self, tmp=None, task_vars=None):
         if task_vars is None:
@@ -14,30 +14,26 @@ class ActionModule(LagoonActionBase):
         del tmp  # tmp no longer has any effect
 
         self._display.v("Task args: %s" % self._task.args)
-
         self.createClient(task_vars)
 
-        
         state = self._task.args.get('state', 'present')
         data = self._task.args.get('data', None)
-        project_id = self._task.args.get('project_id', None)
-        if project_id is not None:
-            project_id = int(project_id)  # Ensure project_id is an integer
-        project_name = self._task.args.get('project_name', None)  
-
-        print(f"State: {state}, Project ID: {project_id}")
-        print(f"Data: {data}")
+        project_id = int(self._task.args.get('project_id', None))
+        project_name = self._task.args.get('project_name', None)
 
         result = {'result': [], 'invalid': [], 'changed': False, 'failed': False}
 
-        if not isinstance(data, dict):
+        if not isinstance(data, (dict, list)):
             result['failed'] = True
-            result['message'] = 'Invalid data type; expected Dict'
+            result['message'] = 'Invalid data type; expected Dict or List'
             return result
 
         try:
-            project_instance = Project(self.client).byName(project_name, ['metadata'])
-            current_metadata = project_instance.projects[0]['metadata'] if project_instance.projects else {}
+            if project_name:
+                project_instance = Project(self.client).byName(project_name, ['metadata'])
+                current_metadata = project_instance.projects[0]['metadata'] if project_instance.projects else {}
+            else:
+                current_metadata = {}  # Assuming no project name means no current metadata
         except Exception as e:
             result['failed'] = True
             result['message'] = f"Error fetching project metadata: {e}"
@@ -46,40 +42,45 @@ class ActionModule(LagoonActionBase):
         lagoonMetadata = Metadata(self.client)
 
         def is_change_required(key, value):
-            # Adjusted to handle potentially missing current_metadata
             return current_metadata.get(key) != value
 
         if state == 'present':
-            for key, value in data.items():
-                if is_change_required(key, value):
-                    try:
-                        update_result = lagoonMetadata.update(project_id, key, value)
-                        print(f"Updated {key}: {update_result}")
-                        result['result'].append({key: value})
-                        result['changed'] = True
-                    except Exception as e:
-                        print(f"Failed to update {key}: {e}")
-                        result['invalid'].append(key)
-                else:
-                    print(f"No change required for {key}")
+            if isinstance(data, list):
+                for item in data:
+                    if not isinstance(item, dict) or 'key' not in item or 'value' not in item:
+                        result['invalid'].append(item)
+                        continue
+                    key, value = item['key'], item['value']
+                    if is_change_required(key, value):
+                        try:
+                            update_result = lagoonMetadata.update(project_id, key, value)
+                            result['result'].append({key: value})
+                            result['changed'] = True
+                        except Exception as e:
+                            result['invalid'].append(key)
+            else:  # if data is a dict
+                for key, value in data.items():
+                    if is_change_required(key, value):
+                        try:
+                            update_result = lagoonMetadata.update(project_id, key, value)
+                            result['result'].append({key: value})
+                            result['changed'] = True
+                        except Exception as e:
+                            result['invalid'].append(key)
 
         elif state == 'absent':
-            for key in data.keys():
+            keys_to_remove = data if isinstance(data, list) else data.keys()
+            for key in keys_to_remove:
                 if key in current_metadata:
                     try:
                         remove_result = lagoonMetadata.remove(project_id, key)
-                        print(f"Removed {key}: {remove_result}")
                         result['result'].append({key: 'removed'})
                         result['changed'] = True
                     except Exception as e:
-                        print(f"Failed to remove {key}: {e}")
                         result['invalid'].append(key)
-                else:
-                    print(f"{key} not present in current metadata.")
 
         if result['invalid']:
             result['failed'] = True
-            result['message'] = f"Errors occurred with keys: {result['invalid']}"
+            result['message'] = f"Errors occurred with keys: {', '.join(result['invalid'])}"
 
-        print(f"Final result: {result}")
         return result

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -21,34 +21,44 @@ class ActionModule(LagoonActionBase):
         project_id = int(self._task.args.get('project_id', None))
         project_name = self._task.args.get('project_name', None)
 
+        print(f"rmk-debug: State={state}, Project ID={project_id}, Project Name={project_name}")
+
         result = {'result': [], 'invalid': [], 'changed': False, 'failed': False}
 
         if not isinstance(data, (dict, list)):
             result['failed'] = True
             result['message'] = 'Invalid data type; expected Dict or List'
+            print("rmk-debug: Invalid data type provided.")
             return result
 
         try:
             if project_name:
                 project_instance = Project(self.client).byName(project_name, ['metadata'])
                 current_metadata = project_instance.projects[0]['metadata'] if project_instance.projects else {}
+                print(f"rmk-debug: Fetched current metadata for project '{project_name}'.")
             else:
                 current_metadata = {}  # Assuming no project name means no current metadata
+                print("rmk-debug: No project name provided, proceeding without current metadata.")
         except Exception as e:
             result['failed'] = True
             result['message'] = f"Error fetching project metadata: {e}"
+            print(f"rmk-debug: Exception caught while fetching project metadata: {e}")
             return result
 
         lagoonMetadata = Metadata(self.client)
 
         def is_change_required(key, value):
-            return current_metadata.get(key) != value
+            required = current_metadata.get(key) != value
+            print(f"rmk-debug: Change required for '{key}'? {required}")
+            return required
 
         if state == 'present':
+            print("rmk-debug: Processing state 'present'.")
             if isinstance(data, list):
                 for item in data:
                     if not isinstance(item, dict) or 'key' not in item or 'value' not in item:
                         result['invalid'].append(item)
+                        print(f"rmk-debug: Invalid item skipped: {item}")
                         continue
                     key, value = item['key'], item['value']
                     if is_change_required(key, value):
@@ -56,8 +66,10 @@ class ActionModule(LagoonActionBase):
                             update_result = lagoonMetadata.update(project_id, key, value)
                             result['result'].append({key: value})
                             result['changed'] = True
+                            print(f"rmk-debug: Updated metadata list for key '{key}' with value '{value}'.")
                         except Exception as e:
                             result['invalid'].append(key)
+                            print(f"rmk-debug: Exception caught list while updating '{key}': {e}")
             else:  # if data is a dict
                 for key, value in data.items():
                     if is_change_required(key, value):
@@ -65,10 +77,13 @@ class ActionModule(LagoonActionBase):
                             update_result = lagoonMetadata.update(project_id, key, value)
                             result['result'].append({key: value})
                             result['changed'] = True
+                            print(f"rmk-debug: Updated metadata for key '{key}' with value '{value}'.")
                         except Exception as e:
                             result['invalid'].append(key)
+                            print(f"rmk-debug: Exception caught while updating '{key}': {e}")
 
         elif state == 'absent':
+            print("rmk-debug: Processing state 'absent'.")
             keys_to_remove = data if isinstance(data, list) else data.keys()
             for key in keys_to_remove:
                 if key in current_metadata:
@@ -76,11 +91,15 @@ class ActionModule(LagoonActionBase):
                         remove_result = lagoonMetadata.remove(project_id, key)
                         result['result'].append({key: 'removed'})
                         result['changed'] = True
+                        print(f"rmk-debug: Removed metadata for key '{key}'.")
                     except Exception as e:
                         result['invalid'].append(key)
+                        print(f"rmk-debug: Exception caught while removing '{key}': {e}")
 
         if result['invalid']:
             result['failed'] = True
             result['message'] = f"Errors occurred with keys: {', '.join(result['invalid'])}"
+            print(f"rmk-debug: Operation completed with errors: {result['invalid']}")
 
+        print(f"rmk-debug: Final result: {result}")
         return result

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -87,6 +87,7 @@ class ActionModule(LagoonActionBase):
         elif state == 'absent':
             print("rmk-debug: Processing state 'absent'.")
             keys_to_remove = [k if isinstance(data, list) else k for k in (data if isinstance(data, list) else data.keys())]
+            print("rmk-debug: Keys to remove -- ", keys_to_remove)
             for key in keys_to_remove:
                 if isinstance(key, dict):  # Handle unexpected dictionary
                     print(f"rmk-debug: Skipping unexpected dict in keys_to_remove: {key}")

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -1,5 +1,6 @@
 from . import LagoonActionBase
 from ..module_utils.gqlMetadata import Metadata
+from ..module_utils.gqlProject import Project
 import json
 
 class ActionModule(LagoonActionBase):
@@ -33,7 +34,7 @@ class ActionModule(LagoonActionBase):
             }
 
         lagoonMetadata = Metadata(self.client)
-        current_metadata = lagoonMetadata.getProjectByName(project_name) if project_name else {}
+        current_metadata = Project(self.client).byName(project_name, ['metadata']) if project_name else {}
 
         def is_change_required(key, value):
             # Check if the current metadata value is different from the intended update

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -33,12 +33,17 @@ class ActionModule(LagoonActionBase):
                 'message': 'Invalid data type (%s) expected List or Dict' % (str(type(data)))
             }
 
-        lagoonMetadata = Metadata(self.client)
-        current_metadata = Project(self.client).byName(project_name, ['metadata']) if project_name else {}
+        # Fetch current metadata 
+        current_metadata = {}
+        if project_name:
+            project_info = Project(self.client).byName(project_name, ['metadata'])
+            current_metadata = project_info['metadata'] if 'metadata' in project_info else {}
 
         def is_change_required(key, value):
             # Check if the current metadata value is different from the intended update
             return current_metadata.get(key) != value
+
+        lagoonMetadata = Metadata(self.client)
 
         if state == 'present':
             for item in (data if isinstance(data, list) else data.items()):

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -14,6 +14,7 @@ class ActionModule(LagoonActionBase):
         del tmp  # tmp no longer has any effect
 
         self._display.v("Task args: %s" % self._task.args)
+        print(f"Debug: Task arguments - {self._task.args}")  # Debug print
 
         self.createClient(task_vars)
 
@@ -22,12 +23,13 @@ class ActionModule(LagoonActionBase):
         project_id = int(self._task.args.get('project_id', None))
         project_name = self._task.args.get('project_name', None)  
 
-        print(f"State: {state}, Project ID: {project_id}")
-        print(f"Data: {data}")
+        print(f"Debug: State - {state}, Project ID - {project_id}, Project Name - {project_name}")  # Debug print
+        print(f"Debug: Data - {data}")  # Debug print
 
         result = {'result': [], 'invalid': [], 'changed': False}
 
         if not isinstance(data, list) and not isinstance(data, dict):
+            print("Debug: Data is neither a list nor a dict")  # Debug print
             return {
                 'failed': True,
                 'message': 'Invalid data type (%s) expected List or Dict' % (str(type(data)))
@@ -36,12 +38,16 @@ class ActionModule(LagoonActionBase):
         # Fetch current metadata using the optimized byName method
         current_metadata = {}
         if project_name:
+            print(f"Debug: Fetching metadata for project {project_name}")  # Debug print
             project_instance = Project(self.client).byName(project_name, ['metadata'])
+            print(f"Debug: Project instance - {project_instance}")  # Debug print
             if project_instance:
+                # Assuming get_metadata() is the correct method to fetch metadata, replace it with the actual method if different
                 project_metadata = project_instance.get_metadata() if hasattr(project_instance, 'get_metadata') else {}
+                print(f"Debug: Current metadata - {project_metadata}")  # Debug print
                 current_metadata = project_metadata if isinstance(project_metadata, dict) else {}
             else:
-                # Handle the case where the project is not found or an error occurred
+                print("Debug: Project instance is None")  # Debug print
                 return {
                     'failed': True,
                     'message': f'Project {project_name} not found or could not retrieve metadata.'
@@ -50,33 +56,37 @@ class ActionModule(LagoonActionBase):
 
         def is_change_required(key, value):
             # Check if the current metadata value is different from the intended update
-            return current_metadata.get(key) != value
+            required = current_metadata.get(key) != value
+            print(f"Debug: Is change required for {key}? - {required}")  # Debug print
+            return required
 
         lagoonMetadata = Metadata(self.client)
 
         if state == 'present':
             for item in (data if isinstance(data, list) else data.items()):
                 key, value = (item['key'], item['value']) if isinstance(item, dict) else item
+                print(f"Debug: Processing {key} with value {value}")  # Debug print
                 if is_change_required(key, value):
                     update_result = lagoonMetadata.update(project_id, key, value)
-                    print(f"Update result: {update_result}")
+                    print(f"Debug: Update result for {key} - {update_result}")  # Debug print
                     result['result'].append(update_result)
                     result['changed'] = True
                 else:
-                    print(f"No change required for {key}")
+                    print(f"Debug: No change required for {key}")
 
         elif state == 'absent':
             for key in (data if isinstance(data, list) else data.keys()):
+                print(f"Debug: Checking for absence of {key}")  # Debug print
                 if key in current_metadata:
                     remove_result = lagoonMetadata.remove(project_id, key)
-                    print(f"Remove result: {remove_result}")
+                    print(f"Debug: Remove result for {key} - {remove_result}")  # Debug print
                     result['result'].append(remove_result)
                     result['changed'] = True
                 else:
-                    print(f"No need to remove {key}, not present")
+                    print(f"Debug: No need to remove {key}, not present")
 
         if len(result['invalid']) > 0:
             result['failed'] = True
 
-        print(f"Final result: {result}")
+        print(f"Debug: Final result - {result}")
         return result

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -86,8 +86,11 @@ class ActionModule(LagoonActionBase):
 
         elif state == 'absent':
             print("rmk-debug: Processing state 'absent'.")
-            keys_to_remove = data if isinstance(data, list) else data.keys()
+            keys_to_remove = [k if isinstance(data, list) else k for k in (data if isinstance(data, list) else data.keys())]
             for key in keys_to_remove:
+                if isinstance(key, dict):  # Handle unexpected dictionary
+                    print(f"rmk-debug: Skipping unexpected dict in keys_to_remove: {key}")
+                    continue  # Skip or handle dictionaries differently
                 if key in current_metadata:
                     try:
                         remove_result = lagoonMetadata.remove(project_id, key)

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -1,6 +1,6 @@
 from . import LagoonActionBase
 from ..module_utils.gqlMetadata import Metadata
-
+import json
 
 class ActionModule(LagoonActionBase):
     ''' Perform comparisons on dictionary objects '''
@@ -19,10 +19,12 @@ class ActionModule(LagoonActionBase):
         state = self._task.args.get('state', 'present')
         data = self._task.args.get('data', None)
         project_id = int(self._task.args.get('project_id', None))
+        project_name = self._task.args.get('project_name', None)  
 
-        result = {}
-        result['result'] = []
-        result['invalid'] = []
+        print(f"State: {state}, Project ID: {project_id}")
+        print(f"Data: {data}")
+
+        result = {'result': [], 'invalid': [], 'changed': False}
 
         if not isinstance(data, list) and not isinstance(data, dict):
             return {
@@ -31,40 +33,35 @@ class ActionModule(LagoonActionBase):
             }
 
         lagoonMetadata = Metadata(self.client)
+        current_metadata = lagoonMetadata.getProjectByName(project_name) if project_name else {}
+
+        def is_change_required(key, value):
+            # Check if the current metadata value is different from the intended update
+            return current_metadata.get(key) != value
 
         if state == 'present':
-            if isinstance(data, list):
-                for item in data:
-                    if not isinstance(item, dict):
-                        result['invalid'].append(item)
-                        continue
-
-                    if 'key' not in item and 'value' not in item:
-                        result['invalid'].append(item)
-                        continue
-
-                    result['result'].append(lagoonMetadata.update(
-                        project_id, item['key'], item['value']))
-
-            else:
-                for key, value in data.items():
-                    result['result'].append(
-                        lagoonMetadata.update(project_id, key, value))
+            for item in (data if isinstance(data, list) else data.items()):
+                key, value = (item['key'], item['value']) if isinstance(item, dict) else item
+                if is_change_required(key, value):
+                    update_result = lagoonMetadata.update(project_id, key, value)
+                    print(f"Update result: {update_result}")
+                    result['result'].append(update_result)
+                    result['changed'] = True
+                else:
+                    print(f"No change required for {key}")
 
         elif state == 'absent':
-            if isinstance(data, list):
-                for key in data:
-                    result['result'].append(
-                        lagoonMetadata.remove(project_id, key))
-            else:
-                for key, value in data.items():
-                    result['result'].append(
-                        lagoonMetadata.remove(project_id, key))
-
-        if len(result['result']) > 0:
-            result['changed'] = True
+            for key in (data if isinstance(data, list) else data.keys()):
+                if key in current_metadata:
+                    remove_result = lagoonMetadata.remove(project_id, key)
+                    print(f"Remove result: {remove_result}")
+                    result['result'].append(remove_result)
+                    result['changed'] = True
+                else:
+                    print(f"No need to remove {key}, not present")
 
         if len(result['invalid']) > 0:
             result['failed'] = True
 
+        print(f"Final result: {result}")
         return result

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -33,11 +33,20 @@ class ActionModule(LagoonActionBase):
                 'message': 'Invalid data type (%s) expected List or Dict' % (str(type(data)))
             }
 
-        # Fetch current metadata 
+        # Fetch current metadata using the optimized byName method
         current_metadata = {}
         if project_name:
-            project_info = Project(self.client).byName(project_name, ['metadata'])
-            current_metadata = project_info['metadata'] if 'metadata' in project_info else {}
+            project_instance = Project(self.client).byName(project_name, ['metadata'])
+            if project_instance:
+                project_metadata = project_instance.get_metadata() if hasattr(project_instance, 'get_metadata') else {}
+                current_metadata = project_metadata if isinstance(project_metadata, dict) else {}
+            else:
+                # Handle the case where the project is not found or an error occurred
+                return {
+                    'failed': True,
+                    'message': f'Project {project_name} not found or could not retrieve metadata.'
+                }
+
 
         def is_change_required(key, value):
             # Check if the current metadata value is different from the intended update

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -86,11 +86,8 @@ class ActionModule(LagoonActionBase):
 
         elif state == 'absent':
             print("rmk-debug: Processing state 'absent'.")
-            keys_to_remove = [k if isinstance(data, list) else k for k in (data if isinstance(data, list) else data.keys())]
+            keys_to_remove = [item['key'] for item in data]
             for key in keys_to_remove:
-                if isinstance(key, dict):  # Handle unexpected dictionary
-                    print(f"rmk-debug: Skipping unexpected dict in keys_to_remove: {key}")
-                    continue  # Skip or handle dictionaries differently
                 if key in current_metadata:
                     try:
                         remove_result = lagoonMetadata.remove(project_id, key)
@@ -100,6 +97,7 @@ class ActionModule(LagoonActionBase):
                     except Exception as e:
                         result['invalid'].append(key)
                         print(f"rmk-debug: Exception caught while removing '{key}': {e}")
+
 
         if result['invalid']:
             result['failed'] = True

--- a/api/plugins/action/metadata.py
+++ b/api/plugins/action/metadata.py
@@ -86,12 +86,20 @@ class ActionModule(LagoonActionBase):
 
         elif state == 'absent':
             print("rmk-debug: Processing state 'absent'.")
-            keys_to_remove = [k if isinstance(data, list) else k for k in (data if isinstance(data, list) else data.keys())]
+            # handle both list and dictionaries
+            if isinstance(data, list):
+                keys_to_remove = []
+                for item in data:
+                    if isinstance(item, dict):
+                        keys_to_remove.append(item['key'])
+                    else:
+                        keys_to_remove.append(item)
+            else:
+                keys_to_remove = list(data.keys())
+
             print("rmk-debug: Keys to remove -- ", keys_to_remove)
+
             for key in keys_to_remove:
-                if isinstance(key, dict):  # Handle unexpected dictionary
-                    print(f"rmk-debug: Skipping unexpected dict in keys_to_remove: {key}")
-                    continue  # Skip or handle dictionaries differently
                 if key in current_metadata:
                     try:
                         remove_result = lagoonMetadata.remove(project_id, key)
@@ -101,6 +109,7 @@ class ActionModule(LagoonActionBase):
                     except Exception as e:
                         result['invalid'].append(key)
                         print(f"rmk-debug: Exception caught while removing '{key}': {e}")
+
 
 
 

--- a/api/plugins/module_utils/gqlMetadata.py
+++ b/api/plugins/module_utils/gqlMetadata.py
@@ -124,25 +124,3 @@ class Metadata(ResourceBase):
             # List & dict cannot be decoded either and will throw a different error.
             except TypeError:
                 continue
-
-
-
-    def getProjectByName(self, project_name: str) -> dict:
-        """
-        Fetch project metadata by project name.
-        """
-        query = """
-        query GetProjectByName($name: String!) {
-            projectByName(name: $name) {
-                metadata
-            }
-        }
-        """
-        variables = {"name": project_name}
-        result = self.client.execute_query(query, variables)
-        project_data = result.get('projectByName', {})
-        metadata = project_data.get('metadata', {})
-        if not isinstance(metadata, dict):
-            metadata = json.loads(metadata)
-        self.unpack(metadata)
-        return metadata

--- a/api/plugins/module_utils/gqlMetadata.py
+++ b/api/plugins/module_utils/gqlMetadata.py
@@ -125,3 +125,24 @@ class Metadata(ResourceBase):
             except TypeError:
                 continue
 
+
+
+    def getProjectByName(self, project_name: str) -> dict:
+        """
+        Fetch project metadata by project name.
+        """
+        query = """
+        query GetProjectByName($name: String!) {
+            projectByName(name: $name) {
+                metadata
+            }
+        }
+        """
+        variables = {"name": project_name}
+        result = self.client.execute_query(query, variables)
+        project_data = result.get('projectByName', {})
+        metadata = project_data.get('metadata', {})
+        if not isinstance(metadata, dict):
+            metadata = json.loads(metadata)
+        self.unpack(metadata)
+        return metadata

--- a/api/plugins/modules/metadata.py
+++ b/api/plugins/modules/metadata.py
@@ -7,6 +7,11 @@ short_description: Manage a project's metadata
 description:
     - Manages a project's metadata.
 options:
+  project_name:
+    description:
+      - The project's name.
+    required: true
+    type: string
   project_id:
     description:
       - The project's ID.
@@ -21,16 +26,46 @@ options:
   data:
     description:
       - The metadata values.
-    type: dict
+    type: dict & list of dicts
     default: None
 '''
 
 EXAMPLES = r'''
-- name: Add project metadata
+- name: Add project metadata (dict)
   lagoon.api.metadata:
     state: present
     data:
       solr-version: 6
+    project_id: 7
+    project_name: project-pheonix
+    
+- name: Add project metadata (list of dicts)
+  lagoon.api.metadata:
+    state: present
+    data:
+      - key: movie
+        value: star-wars
+      - key: music
+        value: rock
+    project_id: 7
+    project_name: project-pheonix
+
+- name: Remove project metadata (dict)
+  lagoon.api.metadata:
+    state: absent
+    data:
+      solr-version: 6
+    project_id: 7
+    project_name: project-pheonix
+
+- name: Add project metadata (list of dicts)
+  lagoon.api.metadata:
+    state: absent
+    data:
+      - key: movie
+        value: star-wars
+      - key: music
+        value: rock
     project_id: 7
     project_name: project-pheonix
 '''

--- a/api/plugins/modules/metadata.py
+++ b/api/plugins/modules/metadata.py
@@ -32,4 +32,5 @@ EXAMPLES = r'''
     data:
       solr-version: 6
     project_id: 7
+    project_name: project-pheonix
 '''


### PR DESCRIPTION
As previously, the Add metadata task showed output as `changed: True` even when there was no change. I fixed this issue by new logic which now has a lookup logic in metadata action plugin, which gathers information for `current_metadata` which is used in function `is_required_change` to compare keys & values. I have also made the required changes when the task is at state == present & state = absent. Additionally, I added some examples on how the task can be used for dict and list of dict in api/plugins/modules/metadata.py.