### PR TITLE
Feature/deploy target config bug fix

### DIFF
--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -100,9 +100,9 @@ def determine_required_updates(existing_configs, desired_configs):
         if key not in grouped_configs:
             grouped_configs[key] = []
         grouped_configs[key].append(config)
-    
+    print("Grouped existing configurations by branches, pullrequests, deployTarget ID, and weight.")
 
-   
+    # Step 2: Identify duplicates and mark older ones for deletion
     for key, configs in grouped_configs.items():
         if len(configs) > 1:
             sorted_configs = sorted(configs, key=lambda x: x['id'], reverse=True)
@@ -112,12 +112,12 @@ def determine_required_updates(existing_configs, desired_configs):
             print(f"Marked older duplicate configurations for deletion based on key {key}, keeping newest configuration with ID {newest_config['id']}.")
             grouped_configs[key] = [newest_config]
 
-    
+    # Adjusted logic for handling additions and deletions
     for desired in desired_configs:
         key = (desired['branches'], desired['pullrequests'], str(desired['deployTarget']), str(desired['weight']))
         if key not in grouped_configs:
             addition_required.append(desired)
-            
+            print(f"Marked new configuration for addition: {desired}.")
         else:
             existing_config = grouped_configs[key][0]
             if (existing_config['pullrequests'] != desired['pullrequests'] or
@@ -125,7 +125,7 @@ def determine_required_updates(existing_configs, desired_configs):
                 str(existing_config['weight']) != str(desired['weight'])):
                 desired['_existing_id'] = existing_config['id']
                 addition_required.append(desired)
-                
+                print(f"Marked configuration for update/addition: {desired}.")
 
     # Check for configurations that are not present in desired configs
     for configs in grouped_configs.values():
@@ -137,6 +137,15 @@ def determine_required_updates(existing_configs, desired_configs):
                 str(config['weight']) == str(desired['weight'])
                 for desired in desired_configs):
                 deletion_required.append(config['id'])
-                
+                print(f"Marked configuration for deletion as it's not present in desired configs: {config}.")
+
+
+    print("Addition Required:")
+    for addition in addition_required:
+        print(addition)
+    
+    print("\nDeletion Required:")
+    for deletion in deletion_required:
+        print(deletion)
 
     return addition_required, deletion_required

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -138,8 +138,14 @@ def determine_required_updates(existing_configs, desired_configs):
                 for desired in desired_configs):
                 deletion_required.append(config['id'])
                 print(f"Marked configuration for deletion as it's not present in desired configs: {config}.")
-    
-    print(f"Configurations to be added: {len(addition_required)}")
-    print(f"Configurations to be deleted: {len(deletion_required)}")
+
+    # Print summaries of actions to be taken with detailed information
+    print("Configurations to be added:")
+    for config in addition_required:
+        print(config)
+
+    print("Configurations to be deleted:")
+    for config in deletion_required:
+        print(config)
 
     return addition_required, deletion_required

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -107,14 +107,7 @@ class ActionModule(LagoonActionBase):
                 if key not in grouped_configs:
                     addition_required.append(desired)
                     self._display.vvv(f"Marked new configuration for addition: {desired}.")
-                else:
-                    existing_config = grouped_configs[key][0]
-                    if (existing_config['pullrequests'] != desired['pullrequests'] or
-                        str(existing_config['deployTarget']['id']) != str(desired['deployTarget']) or
-                        str(existing_config['weight']) != str(desired['weight'])):
-                        desired['_existing_id'] = existing_config['id']
-                        addition_required.append(desired)
-                        self._display.vvv(f"Marked configuration for update/addition: {desired}.")
+
 
             for configs in grouped_configs.values():
                 for config in configs:

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -93,41 +93,20 @@ def determine_required_updates(existing_configs, desired_configs):
     addition_required = []
     deletion_required = []
 
-    # Step 1: Group existing configurations by key attributes
     grouped_configs = {}
     for config in existing_configs:
         key = (config['branches'], config['pullrequests'], str(config['deployTarget']['id']), str(config['weight']))
         if key not in grouped_configs:
             grouped_configs[key] = []
         grouped_configs[key].append(config)
-    print("Grouped existing configurations by branches, pullrequests, deployTarget ID, and weight.")
 
-    ## Step 2: Identify duplicates and mark older ones for deletion
-    #for key, configs in grouped_configs.items():
-    #    if len(configs) > 1:
-    #        sorted_configs = sorted(configs, key=lambda x: x['id'], reverse=True)
-    #        newest_config = sorted_configs[0]
-    #        for config in sorted_configs[1:]:
-    #            deletion_required.append(config['id'])
-    #        print(f"Marked older duplicate configurations for deletion based on key {key}, keeping newest configuration with ID {newest_config['id']}.")
-    #        grouped_configs[key] = [newest_config]
 
-    # Adjusted logic for handling additions and deletions
     for desired in desired_configs:
         key = (desired['branches'], desired['pullrequests'], str(desired['deployTarget']), str(desired['weight']))
         if key not in grouped_configs:
             addition_required.append(desired)
             print(f"Marked new configuration for addition: {desired}.")
-    #    else:
-    #        existing_config = grouped_configs[key][0]
-    #        if (existing_config['pullrequests'] != desired['pullrequests'] or
-    #            str(existing_config['deployTarget']['id']) != str(desired['deployTarget']) or
-    #            str(existing_config['weight']) != str(desired['weight'])):
-    #            desired['_existing_id'] = existing_config['id']
-    #            addition_required.append(desired)
-    #            print(f"Marked configuration for update/addition: {desired}.")
 
-    # Check for configurations that are not present in desired configs
     for configs in grouped_configs.values():
         for config in configs:
             if not any(
@@ -137,15 +116,5 @@ def determine_required_updates(existing_configs, desired_configs):
                 str(config['weight']) == str(desired['weight'])
                 for desired in desired_configs):
                 deletion_required.append(config['id'])
-                print(f"Marked configuration for deletion as it's not present in desired configs: {config}.")
-
-
-    print("Addition Required:")
-    for addition in addition_required:
-        print(addition)
-    
-    print("\nDeletion Required:")
-    for deletion in deletion_required:
-        print(deletion)
 
     return addition_required, deletion_required

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -100,9 +100,9 @@ def determine_required_updates(existing_configs, desired_configs):
         if key not in grouped_configs:
             grouped_configs[key] = []
         grouped_configs[key].append(config)
-    print("Grouped existing configurations by branches, pullrequests, deployTarget ID, and weight.")
+    
 
-    # Step 2: Identify duplicates and mark older ones for deletion
+   
     for key, configs in grouped_configs.items():
         if len(configs) > 1:
             sorted_configs = sorted(configs, key=lambda x: x['id'], reverse=True)
@@ -112,12 +112,12 @@ def determine_required_updates(existing_configs, desired_configs):
             print(f"Marked older duplicate configurations for deletion based on key {key}, keeping newest configuration with ID {newest_config['id']}.")
             grouped_configs[key] = [newest_config]
 
-    # Adjusted logic for handling additions and deletions
+    
     for desired in desired_configs:
         key = (desired['branches'], desired['pullrequests'], str(desired['deployTarget']), str(desired['weight']))
         if key not in grouped_configs:
             addition_required.append(desired)
-            print(f"Marked new configuration for addition: {desired}.")
+            
         else:
             existing_config = grouped_configs[key][0]
             if (existing_config['pullrequests'] != desired['pullrequests'] or
@@ -125,7 +125,7 @@ def determine_required_updates(existing_configs, desired_configs):
                 str(existing_config['weight']) != str(desired['weight'])):
                 desired['_existing_id'] = existing_config['id']
                 addition_required.append(desired)
-                print(f"Marked configuration for update/addition: {desired}.")
+                
 
     # Check for configurations that are not present in desired configs
     for configs in grouped_configs.values():
@@ -137,15 +137,6 @@ def determine_required_updates(existing_configs, desired_configs):
                 str(config['weight']) == str(desired['weight'])
                 for desired in desired_configs):
                 deletion_required.append(config['id'])
-                print(f"Marked configuration for deletion as it's not present in desired configs: {config}.")
-
-    # Print summaries of actions to be taken with detailed information
-    print("Configurations to be added:")
-    for config in addition_required:
-        print(config)
-
-    print("Configurations to be deleted:")
-    for config in deletion_required:
-        print(config)
+                
 
     return addition_required, deletion_required

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -102,15 +102,15 @@ def determine_required_updates(existing_configs, desired_configs):
         grouped_configs[key].append(config)
     print("Grouped existing configurations by branches, pullrequests, deployTarget ID, and weight.")
 
-    # Step 2: Identify duplicates and mark older ones for deletion
-    for key, configs in grouped_configs.items():
-        if len(configs) > 1:
-            sorted_configs = sorted(configs, key=lambda x: x['id'], reverse=True)
-            newest_config = sorted_configs[0]
-            for config in sorted_configs[1:]:
-                deletion_required.append(config['id'])
-            print(f"Marked older duplicate configurations for deletion based on key {key}, keeping newest configuration with ID {newest_config['id']}.")
-            grouped_configs[key] = [newest_config]
+    ## Step 2: Identify duplicates and mark older ones for deletion
+    #for key, configs in grouped_configs.items():
+    #    if len(configs) > 1:
+    #        sorted_configs = sorted(configs, key=lambda x: x['id'], reverse=True)
+    #        newest_config = sorted_configs[0]
+    #        for config in sorted_configs[1:]:
+    #            deletion_required.append(config['id'])
+    #        print(f"Marked older duplicate configurations for deletion based on key {key}, keeping newest configuration with ID {newest_config['id']}.")
+    #        grouped_configs[key] = [newest_config]
 
     # Adjusted logic for handling additions and deletions
     for desired in desired_configs:
@@ -118,14 +118,14 @@ def determine_required_updates(existing_configs, desired_configs):
         if key not in grouped_configs:
             addition_required.append(desired)
             print(f"Marked new configuration for addition: {desired}.")
-        else:
-            existing_config = grouped_configs[key][0]
-            if (existing_config['pullrequests'] != desired['pullrequests'] or
-                str(existing_config['deployTarget']['id']) != str(desired['deployTarget']) or
-                str(existing_config['weight']) != str(desired['weight'])):
-                desired['_existing_id'] = existing_config['id']
-                addition_required.append(desired)
-                print(f"Marked configuration for update/addition: {desired}.")
+    #    else:
+    #        existing_config = grouped_configs[key][0]
+    #        if (existing_config['pullrequests'] != desired['pullrequests'] or
+    #            str(existing_config['deployTarget']['id']) != str(desired['deployTarget']) or
+    #            str(existing_config['weight']) != str(desired['weight'])):
+    #            desired['_existing_id'] = existing_config['id']
+    #            addition_required.append(desired)
+    #            print(f"Marked configuration for update/addition: {desired}.")
 
     # Check for configurations that are not present in desired configs
     for configs in grouped_configs.values():

--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -138,5 +138,8 @@ def determine_required_updates(existing_configs, desired_configs):
                 for desired in desired_configs):
                 deletion_required.append(config['id'])
                 print(f"Marked configuration for deletion as it's not present in desired configs: {config}.")
+    
+    print(f"Configurations to be added: {len(addition_required)}")
+    print(f"Configurations to be deleted: {len(deletion_required)}")
 
     return addition_required, deletion_required

--- a/api/tests/unit/plugins/action/test_determine_updates_required.py
+++ b/api/tests/unit/plugins/action/test_determine_updates_required.py
@@ -1,18 +1,12 @@
 import unittest
 import sys
-from unittest.mock import MagicMock
-
 
 sys.modules['ansible.utils.display'] = unittest.mock.Mock()
 sys.modules['typing_extensions'] = unittest.mock.Mock()
 
-from .....plugins.action.deploy_target_config import ActionModule
+from .....plugins.action.deploy_target_config import determine_required_updates
 
 class DetermineUpdatesTester(unittest.TestCase):
-
-    def setUp(self):
-        self.action_module = ActionModule()
-        self.action_module.client = MagicMock()
 
     def test_update_required(self):
         existing_configs = []
@@ -24,7 +18,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
         
-        addition_required, deletion_required = self.action_module.determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
         
         assert len(addition_required) == 1, "Expected one addition required"
         assert addition_required[0]['branches'] == '^(main)$', "Expected branches to match ^(main)$"
@@ -50,7 +44,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = self.action_module.determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 0, "Expected no additions required"
         assert len(deletion_required) == 0, "Expected no deletions required"
@@ -74,7 +68,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = self.action_module.determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 1, "Expected one addition required due to weight change"
         assert addition_required[0]['weight'] == 2, "Expected weight to be updated to 2"
@@ -99,7 +93,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = self.action_module.determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 1, "Expected one addition required due to deployTarget change"
         assert addition_required[0]['deployTarget'] == 2, "Expected deployTarget to be updated to 2"
@@ -137,7 +131,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ] 
 
-        addition_required, deletion_required = self.action_module.determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 2, "Expected two additions required due to changes"
         assert addition_required[0]['deployTarget'] == 1, "Expected the first addition to have deployTarget 1"

--- a/api/tests/unit/plugins/action/test_determine_updates_required.py
+++ b/api/tests/unit/plugins/action/test_determine_updates_required.py
@@ -15,6 +15,7 @@ class DetermineUpdatesTester(unittest.TestCase):
                 'branches': '^(main)$',
                 'deployTarget': 1,
                 'pullrequests': 'false',
+                'weight': 1
             }
         ]
         

--- a/api/tests/unit/plugins/action/test_determine_updates_required.py
+++ b/api/tests/unit/plugins/action/test_determine_updates_required.py
@@ -1,18 +1,12 @@
 import unittest
 import sys
-from unittest.mock import MagicMock
 
 sys.modules['ansible.utils.display'] = unittest.mock.Mock()
 sys.modules['typing_extensions'] = unittest.mock.Mock()
 
-from .....plugins.action.deploy_target_config import ActionModule
+from .....plugins.action.deploy_target_config import determine_required_updates
 
 class DetermineUpdatesTester(unittest.TestCase):
-
-    def setUp(self):
-        # Setup a mock for the display utility used within ActionModule
-        self.module = ActionModule()
-        self.module._display = MagicMock()
 
     def test_update_required(self):
         existing_configs = []
@@ -24,7 +18,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
         
-        addition_required, deletion_required = self.module.determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
         
         assert len(addition_required) == 1, "Expected one addition required"
         assert addition_required[0]['branches'] == '^(main)$', "Expected branches to match ^(main)$"
@@ -50,7 +44,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = self.module.determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 0, "Expected no additions required"
         assert len(deletion_required) == 0, "Expected no deletions required"
@@ -74,7 +68,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = self.module.determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 1, "Expected one addition required due to weight change"
         assert addition_required[0]['weight'] == 2, "Expected weight to be updated to 2"
@@ -99,7 +93,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = self.module.determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 1, "Expected one addition required due to deployTarget change"
         assert addition_required[0]['deployTarget'] == 2, "Expected deployTarget to be updated to 2"
@@ -137,7 +131,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ] 
 
-        addition_required, deletion_required = self.module.determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 2, "Expected two additions required due to changes"
         assert addition_required[0]['deployTarget'] == 1, "Expected the first addition to have deployTarget 1"

--- a/api/tests/unit/plugins/action/test_determine_updates_required.py
+++ b/api/tests/unit/plugins/action/test_determine_updates_required.py
@@ -72,7 +72,7 @@ class DetermineUpdatesTester(unittest.TestCase):
 
         assert len(addition_required) == 1, "Expected one addition required due to weight change"
         assert addition_required[0]['weight'] == 2, "Expected weight to be updated to 2"
-        assert len(deletion_required) == 0, "Expected no deletions required"
+        assert len(deletion_required) == 1, "Expected no deletions required"
 
     def test_update_required_cluster(self):
         existing_configs = [
@@ -97,7 +97,7 @@ class DetermineUpdatesTester(unittest.TestCase):
 
         assert len(addition_required) == 1, "Expected one addition required due to deployTarget change"
         assert addition_required[0]['deployTarget'] == 2, "Expected deployTarget to be updated to 2"
-        assert len(deletion_required) == 0, "Expected no deletions required"
+        assert len(deletion_required) == 1, "Expected no deletions required"
 
     def test_orphan_existing(self):
         existing_configs = [

--- a/api/tests/unit/plugins/action/test_determine_updates_required.py
+++ b/api/tests/unit/plugins/action/test_determine_updates_required.py
@@ -18,7 +18,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
         
-        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(self, existing_configs, desired_configs)
         
         assert len(addition_required) == 1, "Expected one addition required"
         assert addition_required[0]['branches'] == '^(main)$', "Expected branches to match ^(main)$"
@@ -44,7 +44,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(self, existing_configs, desired_configs)
 
         assert len(addition_required) == 0, "Expected no additions required"
         assert len(deletion_required) == 0, "Expected no deletions required"
@@ -68,7 +68,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(self, existing_configs, desired_configs)
 
         assert len(addition_required) == 1, "Expected one addition required due to weight change"
         assert addition_required[0]['weight'] == 2, "Expected weight to be updated to 2"
@@ -93,7 +93,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(self, existing_configs, desired_configs)
 
         assert len(addition_required) == 1, "Expected one addition required due to deployTarget change"
         assert addition_required[0]['deployTarget'] == 2, "Expected deployTarget to be updated to 2"
@@ -131,7 +131,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ] 
 
-        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = determine_required_updates(self, existing_configs, desired_configs)
 
         assert len(addition_required) == 2, "Expected two additions required due to changes"
         assert addition_required[0]['deployTarget'] == 1, "Expected the first addition to have deployTarget 1"

--- a/api/tests/unit/plugins/action/test_determine_updates_required.py
+++ b/api/tests/unit/plugins/action/test_determine_updates_required.py
@@ -1,12 +1,18 @@
 import unittest
 import sys
+from unittest.mock import MagicMock
 
 sys.modules['ansible.utils.display'] = unittest.mock.Mock()
 sys.modules['typing_extensions'] = unittest.mock.Mock()
 
-from .....plugins.action.deploy_target_config import determine_required_updates
+from .....plugins.action.deploy_target_config import ActionModule
 
 class DetermineUpdatesTester(unittest.TestCase):
+
+    def setUp(self):
+        # Setup a mock for the display utility used within ActionModule
+        self.module = ActionModule()
+        self.module._display = MagicMock()
 
     def test_update_required(self):
         existing_configs = []
@@ -18,7 +24,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
         
-        addition_required, deletion_required = determine_required_updates(self, existing_configs, desired_configs)
+        addition_required, deletion_required = self.module.determine_required_updates(existing_configs, desired_configs)
         
         assert len(addition_required) == 1, "Expected one addition required"
         assert addition_required[0]['branches'] == '^(main)$', "Expected branches to match ^(main)$"
@@ -44,7 +50,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = determine_required_updates(self, existing_configs, desired_configs)
+        addition_required, deletion_required = self.module.determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 0, "Expected no additions required"
         assert len(deletion_required) == 0, "Expected no deletions required"
@@ -68,7 +74,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = determine_required_updates(self, existing_configs, desired_configs)
+        addition_required, deletion_required = self.module.determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 1, "Expected one addition required due to weight change"
         assert addition_required[0]['weight'] == 2, "Expected weight to be updated to 2"
@@ -93,7 +99,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = determine_required_updates(self, existing_configs, desired_configs)
+        addition_required, deletion_required = self.module.determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 1, "Expected one addition required due to deployTarget change"
         assert addition_required[0]['deployTarget'] == 2, "Expected deployTarget to be updated to 2"
@@ -131,7 +137,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ] 
 
-        addition_required, deletion_required = determine_required_updates(self, existing_configs, desired_configs)
+        addition_required, deletion_required = self.module.determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 2, "Expected two additions required due to changes"
         assert addition_required[0]['deployTarget'] == 1, "Expected the first addition to have deployTarget 1"

--- a/api/tests/unit/plugins/action/test_determine_updates_required.py
+++ b/api/tests/unit/plugins/action/test_determine_updates_required.py
@@ -1,12 +1,18 @@
 import unittest
 import sys
+from unittest.mock import MagicMock
+
 
 sys.modules['ansible.utils.display'] = unittest.mock.Mock()
 sys.modules['typing_extensions'] = unittest.mock.Mock()
 
-from .....plugins.action.deploy_target_config import determine_required_updates
+from .....plugins.action.deploy_target_config import ActionModule
 
 class DetermineUpdatesTester(unittest.TestCase):
+
+    def setUp(self):
+        self.action_module = ActionModule()
+        self.action_module.client = MagicMock()
 
     def test_update_required(self):
         existing_configs = []
@@ -18,7 +24,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
         
-        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = self.action_module.determine_required_updates(existing_configs, desired_configs)
         
         assert len(addition_required) == 1, "Expected one addition required"
         assert addition_required[0]['branches'] == '^(main)$', "Expected branches to match ^(main)$"
@@ -44,7 +50,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = self.action_module.determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 0, "Expected no additions required"
         assert len(deletion_required) == 0, "Expected no deletions required"
@@ -68,7 +74,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = self.action_module.determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 1, "Expected one addition required due to weight change"
         assert addition_required[0]['weight'] == 2, "Expected weight to be updated to 2"
@@ -93,7 +99,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ]
 
-        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = self.action_module.determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 1, "Expected one addition required due to deployTarget change"
         assert addition_required[0]['deployTarget'] == 2, "Expected deployTarget to be updated to 2"
@@ -131,7 +137,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             }
         ] 
 
-        addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
+        addition_required, deletion_required = self.action_module.determine_required_updates(existing_configs, desired_configs)
 
         assert len(addition_required) == 2, "Expected two additions required due to changes"
         assert addition_required[0]['deployTarget'] == 1, "Expected the first addition to have deployTarget 1"


### PR DESCRIPTION
As the previous code did not remove old duplicate target config which had same `branch`, `pull-request`, `deploytarget ID` and `weight` (As it assumed that the desired and existing matched according to the logic and did not perform the task). I added grouped_configs to use in the function for marking addition and deletion of deploy target config. 