### PR TITLE
bug fix for deploy target config & updated test

### DIFF
--- a/api/plugins/action/deploy_target_config.py
+++ b/api/plugins/action/deploy_target_config.py
@@ -100,13 +100,23 @@ def determine_required_updates(existing_configs, desired_configs):
             grouped_configs[key] = []
         grouped_configs[key].append(config)
 
+    #Identify duplicates and mark older ones for deletion
+    for key, configs in grouped_configs.items():
+        if len(configs) > 1:
+            sorted_configs = sorted(configs, key=lambda x: x['id'], reverse=True)
+            newest_config = sorted_configs[0]
+            for config in sorted_configs[1:]:
+                deletion_required.append(config['id'])
+            grouped_configs[key] = [newest_config]
 
+    # Adjusted logic for handling additions 
     for desired in desired_configs:
         key = (desired['branches'], desired['pullrequests'], str(desired['deployTarget']), str(desired['weight']))
         if key not in grouped_configs:
             addition_required.append(desired)
-            print(f"Marked new configuration for addition: {desired}.")
+            
 
+    # checking existing configurations for deletions
     for configs in grouped_configs.values():
         for config in configs:
             if not any(
@@ -116,5 +126,6 @@ def determine_required_updates(existing_configs, desired_configs):
                 str(config['weight']) == str(desired['weight'])
                 for desired in desired_configs):
                 deletion_required.append(config['id'])
+                
 
     return addition_required, deletion_required

--- a/api/tests/unit/plugins/action/test_determine_updates_required.py
+++ b/api/tests/unit/plugins/action/test_determine_updates_required.py
@@ -151,8 +151,8 @@ class DetermineUpdatesTester(unittest.TestCase):
             },
             {
                 'branches': '^(main)$',
-                'deployTarget': {'id': 3, 'name': 'cluster.io'},
-                'id': 1,
+                'deployTarget': {'id': 1, 'name': 'cluster.io'},
+                'id': 3,
                 'pullrequests': 'false',
                 'weight': 1
             },

--- a/api/tests/unit/plugins/action/test_determine_updates_required.py
+++ b/api/tests/unit/plugins/action/test_determine_updates_required.py
@@ -151,7 +151,7 @@ class DetermineUpdatesTester(unittest.TestCase):
             },
             {
                 'branches': '^(main)$',
-                'deployTarget': {'id': 1, 'name': 'cluster.io'},
+                'deployTarget': {'id': 3, 'name': 'cluster.io'},
                 'id': 1,
                 'pullrequests': 'false',
                 'weight': 1
@@ -181,5 +181,5 @@ class DetermineUpdatesTester(unittest.TestCase):
 
         addition_required, deletion_required = determine_required_updates(existing_configs, desired_configs)
 
-        assert len(addition_required) == 0, "Expected two additions required due to changes"
+        assert len(addition_required) == 0, "Expected no additions changes"
         assert len(deletion_required) == 1, "Expected one deletion of duplicate deploytarget config"


### PR DESCRIPTION
As the previous code did not remove old duplicate target config which had same `branch`, `pull-request`, `deploytarget ID` and `weight` (As it assumed that the desired and existing matched according to the logic and did not perform the task). I added grouped_configs to use in the function for marking addition and deletion of deploy target config.