### PR TITLE
feat: add a `mutation` action plugin

### DIFF
--- a/api/plugins/action/mutation.py
+++ b/api/plugins/action/mutation.py
@@ -1,0 +1,27 @@
+from gql.dsl import DSLMutation
+from . import LagoonActionBase
+
+class ActionModule(LagoonActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        self.createClient(task_vars)
+
+        mutation = self._task.args.get('mutation')
+        input = self._task.args.get('input')
+        selectType = self._task.args.get('select', None)
+        subfields = self._task.args.get('subfields', [])
+
+        with self.client:
+            mutationObj = self.client.build_dynamic_mutation(
+                mutation, input, selectType, subfields)
+            res = self.client.execute_query_dynamic(DSLMutation(mutationObj))
+            result['result'] = res[mutation]
+            result['changed'] = True
+        return result

--- a/api/plugins/modules/mutation.py
+++ b/api/plugins/modules/mutation.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r'''
+module: mutation
+short_description: Run a mutation against the Lagoon GraphQL API.
+options:
+  mutation:
+    description:
+      - The mutation to run, e.g, addFactsByName.
+    required: true
+    type: str
+  input:
+    description:
+      - Input to pass to the mutation.
+    required: true
+    type: dict
+  select:
+    description:
+      - The type to select from the mutation result.
+    type: str
+    default: null
+  subfields:
+    description:
+      - The subfields to select from the mutation result.
+    type: list
+    default: []
+'''
+
+EXAMPLES = r'''
+- name: Delete a Fact via mutation before creating
+  lagoon.api.mutation:
+    mutation: deleteFact
+    input:
+      environment: "{{ environment_id }}"
+      name: lagoon_logs
+
+- name: Add a Fact for a project
+  lagoon.api.mutation:
+    mutation: addFact
+    input:
+      name: lagoon_logs
+      category: Drupal Module Version
+      environment: "{{ environment_id }}"
+      value: 2.0.0
+      source: ansible_playbook:audit:module_version
+      description: The lagoon_logs module version
+    select: Fact
+    subfields:
+      - id
+
+- name: Delete Facts from a source via mutation before creating
+  lagoon.api.mutation:
+    mutation: deleteFactsFromSource
+    input:
+      environment: "{{ environment_id }}"
+      source: ansible_playbook:audit:module_version
+
+- name: Add multiple Facts for a project
+  lagoon.api.mutation:
+    mutation: addFactsByName
+    input:
+      project: "{{ project_name }}"
+      environment: "{{ environment }}"
+      fact:
+        - name: admin_toolbar
+          category: Drupal Module Version
+          environment_id: "{{ environment_id }}"
+          value: 2.3.0
+          source: ansible_playbook:audit:module_version
+          description: The admin_toolbar module version
+        - name: panelizer
+          category: Drupal Module Version
+          environment_id: "{{ environment_id }}"
+          value: 4.0.0
+          source: ansible_playbook:audit:module_version
+          description: The panelizer module version
+    select: Fact
+    subfields:
+      - id
+'''


### PR DESCRIPTION
[DEVOPS-551]
- Adds support for running dynamic mutations against the GraphQL api.

This allows the following type of playbook:
```yaml
- name: Test mutation
  hosts: localhost
  connection: local
  gather_facts: false
  become: false
  tasks:
    - name: Fetch a Lagoon token.
      lagoon.api.token:
        ssh_options: "-q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
      register: token
    - ansible.builtin.set_fact:
        lagoon_token: "{{ token.token }}"
        lagoon_api_token: "{{ token.token }}"

    - name: Delete a Fact via mutation before creating
      lagoon.api.mutation:
        mutation: deleteFact
        input:
          environment: "{{ environment_id }}"
          name: test_module

    - name: Create a Fact via mutation
      lagoon.api.mutation:
        mutation: addFact
        input:
          name: test_module
          category: Drupal Module Version
          environment: "{{ environment_id }}"
          value: 2.0.0
          source: ansible_playbook:test-mutation
          description: The test_module module version
        select: Fact
        subfields:
          - id

    - name: Delete Facts from a source via mutation before creating
      lagoon.api.mutation:
        mutation: deleteFactsFromSource
        input:
          environment: "{{ environment_id }}"
          source: ansible_playbook:test-mutation

    - name: Create Facts via mutation
      lagoon.api.mutation:
        mutation: addFactsByName
        input:
          project: test-project
          environment: master
          facts:
            - name: test2_module
              category: Drupal Module Version
              value: 2.0.0
              source: ansible_playbook:test-mutation
              description: The test2_module module version
            - name: test3_module
              category: Drupal Module Version
              value: 2.0.0
              source: ansible_playbook:test-mutation
              description: The test3_module module version
        select: Fact
        subfields:
          - id
```

[DEVOPS-551]: https://salsadigital.atlassian.net/browse/DEVOPS-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ