### PR TITLE
[DEVOPS-559] fix: use lagoon access token

### DIFF
--- a/api/plugins/inventory/lagoon.py
+++ b/api/plugins/inventory/lagoon.py
@@ -477,7 +477,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if rc > 0:
             raise AnsibleError("Failed to fetch Lagoon API token: %s (error code: %s) " % (error, rc))
 
-        return token.decode("utf-8").strip()
+        return token['access_token'].strip()
 
 def intWhenStr(val: Union[str,any]) -> Union[int,any]:
     if isinstance(val, str):


### PR DESCRIPTION
PR #88 switched to grant tokens but the InventoryModule class was not updated to support the dict that was returned.

With this change, the access token returned from the grant command will be used for GraphQL queries.