### PR TITLE
Add dynamic mutation action plugin base

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 __pycache__
 api/tests/output
-.vscode
+.vscode/settings.json
 
 .docker/mock-server/node_modules
 .docker/mock-server/package-lock.json

--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ gql-cli https://api.lagoon.amazeeio.cloud/graphql --print-schema \
 
 ## Run unit tests
 ```sh
-docker-compose build
+docker-compose build test
 docker-compose run --rm test units -v --requirements
 ```

--- a/api/plugins/action/__init__.py
+++ b/api/plugins/action/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 
 from ..module_utils.argspec import auth_argument_spec, generate_argspec_from_mutation
-from ..module_utils.gql import GetClientInstance, ProxyLookup, inputArgsToFieldList
+from ..module_utils.gql import GetClientInstance, ProxyLookup, input_args_to_field_list
 from ..module_utils.gqlEnvironment import Environment
 from ..module_utils.gqlProject import Project
 from ansible.errors import AnsibleError
@@ -292,7 +292,7 @@ class LagoonMutationActionBase(LagoonActionBase):
     mutationFieldName = self.actionConfig.fromState(self.action).field
     args = self.moduleArgs
 
-    returnFields = inputArgsToFieldList(args)
+    returnFields = input_args_to_field_list(args)
 
     if (self.action == 'add' and existingRecord is not None and
         self.actionConfig.fromState(self.action).updateField is not None):

--- a/api/plugins/action/__init__.py
+++ b/api/plugins/action/__init__.py
@@ -1,43 +1,148 @@
 import re
 
+from ..module_utils.argspec import auth_argument_spec, generate_argspec_from_mutation
 from ..module_utils.gql import GqlClient
 from ..module_utils.gqlEnvironment import Environment
 from ..module_utils.gqlProject import Project
+from gql.dsl import DSLMutation
+from graphql import GraphQLOutputType
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError
 
 
 class LagoonActionBase(ActionBase):
 
-    def createClient(self, task_vars):
-        if not task_vars.get('lagoon_api_endpoint'):
-            raise AnsibleError("lagoon_api_endpoint is required")
-        if not task_vars.get('lagoon_api_token'):
-            raise AnsibleError("lagoon_api_token is required")
-        self.client = GqlClient(
-            self._templar.template(task_vars.get('lagoon_api_endpoint')).strip(),
-            self._templar.template(task_vars.get('lagoon_api_token')).strip(),
-            self._task.args.get('headers', {}),
-            self._display,
-        )
+  def run(self, tmp=None, task_vars=None):
+    if task_vars is None:
+      task_vars = dict()
 
-    def sanitiseName(self, name: str) -> str:
-        return re.sub(r'[\W_-]+', '-', name)
+    result = super(LagoonActionBase, self).run(tmp, task_vars)
+    del tmp
 
-    def getProjectIdFromName(self, name: str) -> int:
-        lagoonProject = Project(self.client).byName(name, ["id"])
-        if len(lagoonProject.errors):
-            raise AnsibleError("Error fetching project: %s" %
-                               lagoonProject.errors)
-        if not len(lagoonProject.projects):
-            raise AnsibleError(f"Project '{name}' not found")
-        return lagoonProject.projects[0]["id"]
+    self._display.v("Task args: %s" % self._task.args)
+    return result
 
-    def getEnvironmentIdFromNs(self, ns: str) -> int:
-        lagoonEnvironment = Environment(self.client).byNs(ns, ["id"])
-        if len(lagoonEnvironment.errors):
-            raise AnsibleError("Error fetching environment: %s" %
-                                lagoonEnvironment.errors)
-        if not len(lagoonEnvironment.environments):
-            raise AnsibleError(f"Environment '{ns}' not found")
-        return lagoonEnvironment.environments[0]["id"]
+  def createClient(self, task_vars):
+    if not task_vars.get('lagoon_api_endpoint'):
+      raise AnsibleError("lagoon_api_endpoint is required")
+    if not task_vars.get('lagoon_api_token'):
+      raise AnsibleError("lagoon_api_token is required")
+    self.client = GqlClient(
+      self._templar.template(task_vars.get('lagoon_api_endpoint')).strip(),
+      self._templar.template(task_vars.get('lagoon_api_token')).strip(),
+      self._task.args.get('headers', {}),
+      self._display,
+    )
+
+  def sanitiseName(self, name: str) -> str:
+    return re.sub(r'[\W_-]+', '-', name)
+
+  def getProjectIdFromName(self, name: str) -> int:
+    lagoonProject = Project(self.client).byName(name, ["id"])
+    if len(lagoonProject.errors):
+      raise AnsibleError("Error fetching project: %s" % lagoonProject.errors)
+    if not len(lagoonProject.projects):
+      raise AnsibleError(f"Project '{name}' not found")
+    return lagoonProject.projects[0]["id"]
+
+  def getEnvironmentIdFromNs(self, ns: str) -> int:
+    lagoonEnvironment = Environment(self.client).byNs(ns, ["id"])
+    if len(lagoonEnvironment.errors):
+      raise AnsibleError("Error fetching environment: %s" %
+                         lagoonEnvironment.errors)
+    if not len(lagoonEnvironment.environments):
+      raise AnsibleError(f"Environment '{ns}' not found")
+    return lagoonEnvironment.environments[0]["id"]
+
+
+class LagoonMutationActionBase(LagoonActionBase):
+  """Action plugins base class for Lagoon mutations.
+
+  Base class for Lagoon actions that perform mutations, providing the
+  ability to first verify existence, delete & recreate, or create if
+  missing.
+
+  All args for the plugin are inferred from the GraphQL schema, and
+  the mutationInputField() method must be implemented to return the
+  name of the input field for the mutation.
+
+  Additional arguments can be provided by implementing the additionalArgs()
+  method, and aliases for arguments can be provided by implementing the
+  argsAliases() method.
+  """
+
+  mutationPluginConfig = dict()
+  hasStateField = False
+  hasInputWrapper = False
+  moduleArgs = dict()
+  action = None
+
+  def run(self, tmp=None, task_vars=None):
+    result = super(LagoonMutationActionBase, self).run(tmp, task_vars)
+
+    self.validatePluginConfig()
+
+    self.createClient(task_vars)
+
+    # Common auth arguments.
+    argSpec = auth_argument_spec()
+
+    action = 'add'
+    if self.hasStateField:
+      argSpec['state'] = dict(
+        type='str',
+        default='present',
+        choices=['absent', 'present'],
+      )
+
+      if self._task.args.get('state', 'present') == 'absent':
+        action = 'delete'
+
+    # Generate the argspec from the schema.
+    genArgSpec = generate_argspec_from_mutation(
+      self.client,
+      self.mutationPluginConfig.get(action).get('mutation'),
+      self.mutationPluginConfig.get(action).get('inputFieldAdditionalArgs', {}),
+      self.mutationPluginConfig.get(action).get('inputFieldArgsAliases', {}),
+    )
+    if len(genArgSpec) == 1 and 'input' in genArgSpec:
+      self.hasInputWrapper = True
+      genArgSpec = genArgSpec['input']['elements']
+    argSpec.update(genArgSpec)
+
+    # Validate the arguments.
+    _, moduleArgs = self.validate_argument_spec(argSpec)
+    self.moduleArgs = moduleArgs
+    self.determineAction()
+
+    # if self.action == 'delete':
+    #   mutationObj = self.client.build_dynamic_mutation(
+    #     self.mutationPluginConfig.get(action).get('mutation'),
+    #     moduleArgs, returnType, subfields)
+    #   res = self.client.execute_query_dynamic(DSLMutation(mutationObj))
+
+    return result
+
+  def validatePluginConfig(self):
+    if (self.mutationPluginConfig is None or
+      not isinstance(self.mutationPluginConfig, dict)):
+      raise AnsibleError("Invalid mutation plugin configuration")
+
+    if len(self.mutationPluginConfig.keys()) == 0:
+      raise AnsibleError("No mutation plugin configuration found")
+
+    if self.hasAdd() and self.hasDelete():
+      self.hasStateField = True
+
+  def hasAdd(self):
+    return self.mutationPluginConfig.get('add') is not None
+
+  def hasDelete(self):
+    return self.mutationPluginConfig.get('delete') is not None
+
+  def determineAction(self):
+    if self.hasStateField:
+      if self.moduleArgs.get('state', 'present') == 'present':
+        self.action = 'add'
+      elif self.moduleArgs.get('state', 'present') == 'absent':
+        self.action = 'delete'

--- a/api/plugins/action/__init__.py
+++ b/api/plugins/action/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 from ..module_utils.argspec import auth_argument_spec, generate_argspec_from_mutation

--- a/api/plugins/action/mutation.py
+++ b/api/plugins/action/mutation.py
@@ -1,5 +1,5 @@
-from gql.dsl import DSLMutation
 from . import LagoonActionBase
+from gql.dsl import DSLMutation
 
 class ActionModule(LagoonActionBase):
 
@@ -15,12 +15,11 @@ class ActionModule(LagoonActionBase):
 
         mutation = self._task.args.get('mutation')
         input = self._task.args.get('input')
-        selectType = self._task.args.get('select', None)
-        subfields = self._task.args.get('subfields', [])
+        subfields = self._task.args.get('subfields', ['id'])
 
         with self.client:
             mutationObj = self.client.build_dynamic_mutation(
-                mutation, input, selectType, subfields)
+                mutation, input, subfields)
             res = self.client.execute_query_dynamic(DSLMutation(mutationObj))
             result['result'] = res[mutation]
             result['changed'] = True

--- a/api/plugins/action/task_definition.py
+++ b/api/plugins/action/task_definition.py
@@ -4,84 +4,84 @@ from ..module_utils.gql import ProxyLookup
 
 class ActionModule(LagoonMutationActionBase):
 
-    actionConfig = MutationActionConfig(
-        name='task_definition',
+  actionConfig = MutationActionConfig(
+    name='task_definition',
 
-        # Configuration for adding a new task definition.
-        add=MutationConfig(
-            # GraphQL Mutation for adding a new task definition.
-            field="addAdvancedTaskDefinition",
+    # Configuration for adding a new task definition.
+    add=MutationConfig(
+      # GraphQL Mutation for adding a new task definition.
+      field="addAdvancedTaskDefinition",
 
-            # GraphQL Mutation for updating an existing task definition.
-            updateField="updateAdvancedTaskDefinition",
+      # GraphQL Mutation for updating an existing task definition.
+      updateField="updateAdvancedTaskDefinition",
 
-            # Additional arguments to be allowed when calling the action
-            # plugin. These arguments will not be passed to the GraphQL
-            # mutation, but would instead be used to lookup a project by name
-            # in one of the proxy lookups.
-            inputFieldAdditionalArgs=dict(project_name=dict(type="str")),
+      # Additional arguments to be allowed when calling the action
+      # plugin. These arguments will not be passed to the GraphQL
+      # mutation, but would instead be used to lookup a project by name
+      # in one of the proxy lookups.
+      inputFieldAdditionalArgs=dict(project_name=dict(type="str")),
 
-            # Aliases for the input fields - in this case used to maintain
-            # compatibility with the previous version of the plugin.
-            inputFieldArgsAliases=dict(
-                type=["task_type"],
-                advancedTaskDefinitionArguments=["arguments"],
-            ),
+      # Aliases for the input fields - in this case used to maintain
+      # compatibility with the previous version of the plugin.
+      inputFieldArgsAliases=dict(
+        type=["task_type"],
+        advancedTaskDefinitionArguments=["arguments"],
+      ),
 
-            # Proxy lookups to be used when looking for existing task
-            # definitions. A first pass is done through the lookups in the
-            # order they are provided, to find one that matches the input
-            # of the plugin. The first one matched is then used to query
-            # task definitions and compare them with the input, using the
-            # lookupCompareFields and diffCompareFields.
-            proxyLookups=[
-                # Will use 'id' if provided to lookup a task definition by id.
-                ProxyLookup(query="advancedTaskDefinitionById"),
+      # Proxy lookups to be used when looking for existing task
+      # definitions. A first pass is done through the lookups in the
+      # order they are provided, to find one that matches the input
+      # of the plugin. The first one matched is then used to query
+      # task definitions and compare them with the input, using the
+      # lookupCompareFields and diffCompareFields.
+      proxyLookups=[
+        # Will use 'id' if provided to lookup a task definition by id.
+        ProxyLookup(query="advancedTaskDefinitionById"),
 
-                # Will use 'environment' id if provided to find all task
-                # definitions by environment id, then filter by the fields
-                # in lookupCompareFields.
-                ProxyLookup(query="advancedTasksForEnvironment"),
+        # Will use 'environment' id if provided to find all task
+        # definitions by environment id, then filter by the fields
+        # in lookupCompareFields.
+        ProxyLookup(query="advancedTasksForEnvironment"),
 
-                # Will use 'project_name' if provided to find all task
-                # definitions for a project through projectByName, selecting
-                # the fields in selectFields recursively, then filter by the
-                # fields in lookupCompareFields.
-                # This would be similar to the following:
-                #   query {
-                #     projectByName(project_name: "{{ project_name }}") {
-                #       environments {
-                #         advancedTasks {
-                #           id
-                #           ...
-                #         }
-                #       }
-                #     }
-                #   }
-                ProxyLookup(query="projectByName",
-                            inputArgFields={"project_name": "name"},
-                            selectFields=["environments", "advancedTasks"],
-                ),
-            ],
-
-            # These fields are used to determine whether the task definition
-            # already exists.
-            lookupCompareFields=["name"],
-
-            # These fields are used to determine whether the task definition
-            # needs to be updated. If any of the values of these fields are
-            # different between the existing task definition and the input,
-            # the task definition will be updated.
-            diffCompareFields=[
-                "permission",
-                "description",
-                "service",
-                "advancedTaskDefinitionArguments",
-                "deployTokenInjection",
-                "projectKeyInjection",
-            ],
+        # Will use 'project_name' if provided to find all task
+        # definitions for a project through projectByName, selecting
+        # the fields in selectFields recursively, then filter by the
+        # fields in lookupCompareFields.
+        # This would be similar to the following:
+        #   query {
+        #     projectByName(project_name: "{{ project_name }}") {
+        #       environments {
+        #         advancedTasks {
+        #           id
+        #           ...
+        #         }
+        #       }
+        #     }
+        #   }
+        ProxyLookup(query="projectByName",
+                    inputArgFields={"project_name": "name"},
+                    selectFields=["environments", "advancedTasks"],
         ),
+      ],
 
-        # Configuration for deleting a task definition.
-        delete=MutationConfig(field="deleteAdvancedTaskDefinition"),
-    )
+      # These fields are used to determine whether the task definition
+      # already exists.
+      lookupCompareFields=["name"],
+
+      # These fields are used to determine whether the task definition
+      # needs to be updated. If any of the values of these fields are
+      # different between the existing task definition and the input,
+      # the task definition will be updated.
+      diffCompareFields=[
+        "permission",
+        "description",
+        "service",
+        "advancedTaskDefinitionArguments",
+        "deployTokenInjection",
+        "projectKeyInjection",
+      ],
+    ),
+
+    # Configuration for deleting a task definition.
+    delete=MutationConfig(field="deleteAdvancedTaskDefinition"),
+  )

--- a/api/plugins/action/task_definition.py
+++ b/api/plugins/action/task_definition.py
@@ -1,31 +1,77 @@
 from . import LagoonMutationActionBase, MutationConfig, MutationActionConfig
 from ..module_utils.gql import ProxyLookup
-from ..module_utils.gqlProject import Project
-from ..module_utils.gqlTaskDefinition import TaskDefinition
-from ansible.errors import AnsibleError, AnsibleOptionsError
 
 
 class ActionModule(LagoonMutationActionBase):
 
     actionConfig = MutationActionConfig(
         name='task_definition',
+
+        # Configuration for adding a new task definition.
         add=MutationConfig(
+            # GraphQL Mutation for adding a new task definition.
             field="addAdvancedTaskDefinition",
+
+            # GraphQL Mutation for updating an existing task definition.
             updateField="updateAdvancedTaskDefinition",
+
+            # Additional arguments to be allowed when calling the action
+            # plugin. These arguments will not be passed to the GraphQL
+            # mutation, but would instead be used to lookup a project by name
+            # in one of the proxy lookups.
             inputFieldAdditionalArgs=dict(project_name=dict(type="str")),
+
+            # Aliases for the input fields - in this case used to maintain
+            # compatibility with the previous version of the plugin.
             inputFieldArgsAliases=dict(
                 type=["task_type"],
                 advancedTaskDefinitionArguments=["arguments"],
             ),
+
+            # Proxy lookups to be used when looking for existing task
+            # definitions. A first pass is done through the lookups in the
+            # order they are provided, to find one that matches the input
+            # of the plugin. The first one matched is then used to query
+            # task definitions and compare them with the input, using the
+            # lookupCompareFields and diffCompareFields.
             proxyLookups=[
+                # Will use 'id' if provided to lookup a task definition by id.
                 ProxyLookup(query="advancedTaskDefinitionById"),
+
+                # Will use 'environment' id if provided to find all task
+                # definitions by environment id, then filter by the fields
+                # in lookupCompareFields.
                 ProxyLookup(query="advancedTasksForEnvironment"),
+
+                # Will use 'project_name' if provided to find all task
+                # definitions for a project through projectByName, selecting
+                # the fields in selectFields recursively, then filter by the
+                # fields in lookupCompareFields.
+                # This would be similar to the following:
+                #   query {
+                #     projectByName(project_name: "{{ project_name }}") {
+                #       environments {
+                #         advancedTasks {
+                #           id
+                #           ...
+                #         }
+                #       }
+                #     }
+                #   }
                 ProxyLookup(query="projectByName",
                             inputArgFields={"project_name": "name"},
                             selectFields=["environments", "advancedTasks"],
                 ),
             ],
+
+            # These fields are used to determine whether the task definition
+            # already exists.
             lookupCompareFields=["name"],
+
+            # These fields are used to determine whether the task definition
+            # needs to be updated. If any of the values of these fields are
+            # different between the existing task definition and the input,
+            # the task definition will be updated.
             diffCompareFields=[
                 "permission",
                 "description",
@@ -35,205 +81,7 @@ class ActionModule(LagoonMutationActionBase):
                 "projectKeyInjection",
             ],
         ),
+
+        # Configuration for deleting a task definition.
         delete=MutationConfig(field="deleteAdvancedTaskDefinition"),
     )
-
-    def old_run(self, tmp=None, task_vars=None):
-
-        if task_vars is None:
-            task_vars = dict()
-
-        result = super(ActionModule, self).run(tmp, task_vars)
-        del tmp
-
-        self._display.v("Task args: %s" % self._task.args)
-
-        self.createClient(task_vars)
-
-        task_type = self._task.args.get("task_type")
-        permission = self._task.args.get("permission")
-        project = self._task.args.get("project")
-        environment = self._task.args.get("environment")
-        name = self._task.args.get("name")
-        description = self._task.args.get("description")
-        service = self._task.args.get("service")
-        image = self._task.args.get("image")
-        command = self._task.args.get("command")
-        arguments = self._task.args.get("arguments", [])
-        deploy_token_injection = self._task.args.get("deploy_token_injection", False)
-        project_key_injection = self._task.args.get("project_key_injection", False)
-        state = self._task.args.get("state")
-
-        project_id = None
-        environment_id = None
-
-        if state == "absent" and not project:
-            raise AnsibleOptionsError("Project name is required when deleting")
-
-        if environment:
-            self._display.warning(
-                "Environment-specific tasks are not currently supported; "+
-                "skipping environment name.")
-            environment = None
-
-        lagoonTaskDefinition = TaskDefinition(self.client)
-
-        existing_task_definitions = {}
-        # Fetch all task definitions.
-        if not project and not environment:
-            existing_task_definitions = lagoonTaskDefinition.get_definitions()
-        # Fetch definitions only for the specific project's environment.
-        elif project and environment:
-            project_id = self.get_project_id(project)
-            environment_id = self.getEnvironmentIdFromNs(
-                self.sanitiseName(f"{project}-{environment}"))
-            existing_task_definitions = lagoonTaskDefinition.get_definitions(
-                project_id=project_id, environment_id=environment_id)
-        elif project:
-            project_id = self.get_project_id(project)
-            existing_task_definitions = lagoonTaskDefinition.get_definitions(
-                project_id=project_id)
-        else:
-            environment_id = self.getEnvironmentIdFromNs(
-                self.sanitiseName(f"{project}-{environment}"))
-            existing_task_definitions = lagoonTaskDefinition.get_definitions(
-                environment_ids=environment_id)
-
-        found_def = False
-        for existing_task_def in existing_task_definitions:
-            if existing_task_def["name"] == name:
-                found_def = existing_task_def
-
-        if not found_def and state == "absent":
-            result["changed"] = False
-        elif found_def and state == "absent":
-            result["changed"] = True
-            result["result"] = lagoonTaskDefinition.delete(found_def["id"])
-        # Update existing if required.
-        elif found_def:
-            changed, deleteAndAdd = self.def_has_changed(
-                found_def,
-                {
-                    "type": task_type,
-                    "permission": permission,
-                    "description": description,
-                    "service": service,
-                    "command": command,
-                    "image": image,
-                    "arguments": arguments,
-                    "deployTokenInjection": deploy_token_injection,
-                    "projectKeyInjection": project_key_injection,
-                }
-            )
-            if deleteAndAdd:
-                lagoonTaskDefinition.delete(found_def["id"])
-                result["result"] = lagoonTaskDefinition.add(
-                    task_type,
-                    permission,
-                    project_id if project_id else None,
-                    environment_id if environment_id else None,
-                    name,
-                    description,
-                    service,
-                    image,
-                    command,
-                    arguments,
-                    deploy_token_injection,
-                    project_key_injection
-                )
-                result["changed"] = True
-            elif changed:
-                result["changed"] = True
-                result["result"] = lagoonTaskDefinition.update(
-                    found_def["id"],
-                    task_type,
-                    permission,
-                    project_id if project_id else None,
-                    environment_id if environment_id else None,
-                    name,
-                    description,
-                    service,
-                    image,
-                    command,
-                    arguments,
-                    deploy_token_injection,
-                    project_key_injection
-                )
-            else:
-                result["changed"] = False
-        # Create new.
-        else:
-            result["changed"] = True
-            result["result"] = lagoonTaskDefinition.add(
-                task_type,
-                permission,
-                project_id if project_id else None,
-                environment_id if environment_id else None,
-                name,
-                description,
-                service,
-                image,
-                command,
-                arguments,
-                deploy_token_injection,
-                project_key_injection
-            )
-
-        return result
-
-    def get_project_id(self, name: str):
-        lagoonProject = Project(self.client).byName(name, ["id"])
-        if len(lagoonProject.errors):
-            raise AnsibleError("Error fetching project: %s" % lagoonProject.errors)
-        if not len(lagoonProject.projects):
-            raise AnsibleError(f"Project '{name}' not found")
-        return lagoonProject.projects[0]["id"]
-
-    def def_has_changed(self, current: dict, desired: dict) -> tuple[bool, bool]:
-        # If the type has changed, we need to delete and add.
-        if current["type"] != desired["type"]:
-            return True, True
-
-        compare_fields = [
-            "permission",
-            "description",
-            "service",
-            "arguments",
-            "deployTokenInjection",
-            "projectKeyInjection",
-        ]
-        for field in compare_fields:
-            if field == "arguments":
-                if self.args_have_changed(current["advancedTaskDefinitionArguments"], desired["arguments"]):
-                    return True, False
-                continue
-            if current[field] != desired[field]:
-                return True, False
-
-        if current["type"] == "COMMAND" and current["command"] != desired["command"]:
-            return True, False
-
-        if current["type"] == "IMAGE" and current["image"] != desired["image"]:
-            return True, False
-
-        return False, False
-
-    def args_have_changed(self, current: list, desired: list) -> bool:
-        if not len(current) and not len(desired):
-            return False
-
-        if len(current) != len(desired):
-            return True
-
-        compare_fields = [
-            "name",
-            "displayName",
-            "type"
-        ]
-
-        for i in range(len(current)):
-            for field in compare_fields:
-                if current[i][field] != desired[i][field]:
-                    return True
-
-        return False

--- a/api/plugins/action/task_definition.py
+++ b/api/plugins/action/task_definition.py
@@ -1,4 +1,5 @@
-from . import LagoonMutationActionBase
+from . import LagoonMutationActionBase, MutationConfig, MutationActionConfig
+from ..module_utils.gql import ProxyLookup
 from ..module_utils.gqlProject import Project
 from ..module_utils.gqlTaskDefinition import TaskDefinition
 from ansible.errors import AnsibleError, AnsibleOptionsError
@@ -6,19 +7,22 @@ from ansible.errors import AnsibleError, AnsibleOptionsError
 
 class ActionModule(LagoonMutationActionBase):
 
-    mutationPluginConfig = dict(
-        add=dict(
-            mutation="addAdvancedTaskDefinition",
-            inputField="AdvancedTaskDefinitionInput",
-            inputFieldArgsAliases=dict(type=['task_type']),
-            returnType="AdvancedTaskDefinition",
+    actionConfig = MutationActionConfig(
+        name='task_definition',
+        add=MutationConfig(
+            field="addAdvancedTaskDefinition",
+            inputFieldAdditionalArgs=dict(project_name=dict(type="str")),
+            inputFieldArgsAliases=dict(type=["task_type"]),
+            proxyLookups=[
+                ProxyLookup(query="advancedTaskDefinitionById"),
+                ProxyLookup(query="advancedTasksForEnvironment"),
+                ProxyLookup(query="projectByName",
+                            inputArgField="project_name",
+                            fields=["environments", "advancedTasks"],
+                ),
+            ]
         ),
-        delete=dict(
-            mutation="deleteAdvancedTaskDefinition",
-            inputField="advancedTaskDefinition",
-            inputFieldArgsAliases=dict(type=['task_type']),
-            returnType="String",
-        ),
+        delete=MutationConfig(field="deleteAdvancedTaskDefinition"),
     )
 
     def old_run(self, tmp=None, task_vars=None):

--- a/api/plugins/action/task_definition.py
+++ b/api/plugins/action/task_definition.py
@@ -1,12 +1,27 @@
-from . import LagoonActionBase
+from . import LagoonMutationActionBase
 from ..module_utils.gqlProject import Project
 from ..module_utils.gqlTaskDefinition import TaskDefinition
 from ansible.errors import AnsibleError, AnsibleOptionsError
 
 
-class ActionModule(LagoonActionBase):
+class ActionModule(LagoonMutationActionBase):
 
-    def run(self, tmp=None, task_vars=None):
+    mutationPluginConfig = dict(
+        add=dict(
+            mutation="addAdvancedTaskDefinition",
+            inputField="AdvancedTaskDefinitionInput",
+            inputFieldArgsAliases=dict(type=['task_type']),
+            returnType="AdvancedTaskDefinition",
+        ),
+        delete=dict(
+            mutation="deleteAdvancedTaskDefinition",
+            inputField="advancedTaskDefinition",
+            inputFieldArgsAliases=dict(type=['task_type']),
+            returnType="String",
+        ),
+    )
+
+    def old_run(self, tmp=None, task_vars=None):
 
         if task_vars is None:
             task_vars = dict()

--- a/api/plugins/action/task_definition.py
+++ b/api/plugins/action/task_definition.py
@@ -13,7 +13,10 @@ class ActionModule(LagoonMutationActionBase):
             field="addAdvancedTaskDefinition",
             updateField="updateAdvancedTaskDefinition",
             inputFieldAdditionalArgs=dict(project_name=dict(type="str")),
-            inputFieldArgsAliases=dict(type=["task_type"]),
+            inputFieldArgsAliases=dict(
+                type=["task_type"],
+                advancedTaskDefinitionArguments=["arguments"],
+            ),
             proxyLookups=[
                 ProxyLookup(query="advancedTaskDefinitionById"),
                 ProxyLookup(query="advancedTasksForEnvironment"),
@@ -22,7 +25,15 @@ class ActionModule(LagoonMutationActionBase):
                             selectFields=["environments", "advancedTasks"],
                 ),
             ],
-            compareFields=["name"],
+            lookupCompareFields=["name"],
+            diffCompareFields=[
+                "permission",
+                "description",
+                "service",
+                "advancedTaskDefinitionArguments",
+                "deployTokenInjection",
+                "projectKeyInjection",
+            ],
         ),
         delete=MutationConfig(field="deleteAdvancedTaskDefinition"),
     )

--- a/api/plugins/action/task_definition.py
+++ b/api/plugins/action/task_definition.py
@@ -11,16 +11,18 @@ class ActionModule(LagoonMutationActionBase):
         name='task_definition',
         add=MutationConfig(
             field="addAdvancedTaskDefinition",
+            updateField="updateAdvancedTaskDefinition",
             inputFieldAdditionalArgs=dict(project_name=dict(type="str")),
             inputFieldArgsAliases=dict(type=["task_type"]),
             proxyLookups=[
                 ProxyLookup(query="advancedTaskDefinitionById"),
                 ProxyLookup(query="advancedTasksForEnvironment"),
                 ProxyLookup(query="projectByName",
-                            inputArgField="project_name",
-                            fields=["environments", "advancedTasks"],
+                            inputArgFields={"project_name": "name"},
+                            selectFields=["environments", "advancedTasks"],
                 ),
-            ]
+            ],
+            compareFields=["name"],
         ),
         delete=MutationConfig(field="deleteAdvancedTaskDefinition"),
     )

--- a/api/plugins/module_utils/argspec.py
+++ b/api/plugins/module_utils/argspec.py
@@ -1,0 +1,85 @@
+from .gql import GqlClient
+from gql.dsl import DSLField
+from graphql import (
+  GraphQLEnumType,
+  GraphQLInputField,
+  GraphQLInputObjectType,
+  GraphQLInputType,
+  GraphQLList,
+  GraphQLNonNull
+)
+from graphql.type.definition import (
+  GraphQLArgument,
+  is_enum_type,
+  is_input_object_type,
+  is_list_type,
+  is_non_null_type,
+  is_scalar_type
+)
+from typing import cast
+
+def auth_argument_spec(spec=None) -> dict:
+  arg_spec = (dict(
+    api_endpoint=dict(
+      type='str',
+      aliases=['lagoon_api_endpoint', 'lagoon_endpoint']),
+    api_token=dict(
+      type='str', no_log=True,
+      aliases=['lagoon_api_token', 'lagoon_token']),
+  ))
+  if spec:
+    arg_spec.update(spec)
+  return arg_spec
+
+def generate_argspec_from_mutation(
+    client: GqlClient, mutation: str,
+    additionalArgs: dict = {}, aliases: dict = {}) -> dict:
+
+  with client:
+    mutationField: DSLField = getattr(client.ds.Mutation, mutation)
+    argSpec = dict()
+    arg: GraphQLArgument
+    for fieldName, arg in mutationField.field.args.items():
+      argSpec[fieldName] = generate_argspec_for_input_type(arg.type, aliases)
+    argSpec.update(additionalArgs)
+    return argSpec
+
+def generate_argspec_from_input_object_type(
+    objType: GraphQLInputObjectType, aliases: dict) -> dict:
+
+  argSpec = dict()
+  fields = objType.fields
+  field: GraphQLInputField
+  for fieldName, field in fields.items():
+    argSpec[fieldName] = generate_argspec_for_input_type(field.type, aliases)
+    if fieldName in aliases:
+      argSpec[fieldName]['aliases'] = aliases[fieldName]
+  return argSpec
+
+def generate_argspec_for_input_type(inputType: GraphQLInputType, aliases: dict) -> dict:
+  if is_scalar_type(inputType):
+    if inputType.name == 'Boolean':
+      return dict(type='bool')
+    elif inputType.name == 'Int':
+      return dict(type='int')
+    else:
+      return dict(type='str')
+  elif is_non_null_type(inputType):
+    nonNullType = cast(GraphQLNonNull, inputType)
+    argSpec = generate_argspec_for_input_type(nonNullType.of_type, aliases)
+    argSpec['required'] = True
+    return argSpec
+  elif is_enum_type(inputType):
+    enumType = cast(GraphQLEnumType, inputType)
+    return dict(type='str', choices=[enumVal for enumVal in enumType.values.keys()])
+  elif is_list_type(inputType):
+    listType = cast(GraphQLList, inputType)
+    return generate_argspec_for_input_type(listType.of_type, aliases)
+  elif is_input_object_type(inputType):
+    objType = cast(GraphQLInputObjectType, inputType)
+    return dict(
+      type='dict',
+      elements=generate_argspec_from_input_object_type(objType, aliases))
+  else:
+    print('inputType', inputType.to_kwargs(), "\n")
+    raise Exception("Unsupported input type found when generating argspec")

--- a/api/plugins/module_utils/argspec.py
+++ b/api/plugins/module_utils/argspec.py
@@ -42,7 +42,7 @@ def generate_argspec_from_mutation(
 
   if 'input' in argSpec:
     argSpec['input']['options'].update(additionalArgs)
-  else:
+  elif additionalArgs:
     argSpec.update(additionalArgs)
   return argSpec
 

--- a/api/plugins/module_utils/gql.py
+++ b/api/plugins/module_utils/gql.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .display import Display
 from ansible.module_utils.errors import AnsibleValidationError
 from gql import Client, gql

--- a/api/plugins/modules/mutation.py
+++ b/api/plugins/modules/mutation.py
@@ -15,16 +15,11 @@ options:
       - Input to pass to the mutation.
     required: true
     type: dict
-  select:
-    description:
-      - The type to select from the mutation result.
-    type: str
-    default: null
   subfields:
     description:
       - The subfields to select from the mutation result.
     type: list
-    default: []
+    default: [id]
 '''
 
 EXAMPLES = r'''
@@ -45,9 +40,6 @@ EXAMPLES = r'''
       value: 2.0.0
       source: ansible_playbook:audit:module_version
       description: The lagoon_logs module version
-    select: Fact
-    subfields:
-      - id
 
 - name: Delete Facts from a source via mutation before creating
   lagoon.api.mutation:
@@ -75,7 +67,4 @@ EXAMPLES = r'''
           value: 4.0.0
           source: ansible_playbook:audit:module_version
           description: The panelizer module version
-    select: Fact
-    subfields:
-      - id
 '''

--- a/api/tests/common/__init__.py
+++ b/api/tests/common/__init__.py
@@ -1,6 +1,6 @@
 from os.path import dirname, realpath
 from gql.client import SyncClientSession
-from gql.dsl import dsl_gql, DSLExecutable, DSLField, DSLQuery, print_ast
+from gql.dsl import dsl_gql, DSLExecutable, DSLField, DSLMutation, DSLQuery, print_ast
 from graphql import GraphQLSchema, build_ast_schema, parse
 from unittest.mock import MagicMock
 
@@ -17,6 +17,9 @@ def load_schema() -> GraphQLSchema:
 
 def dsl_field_query_to_str(query: DSLField) -> str:
     return print_ast(dsl_gql(DSLQuery(query)))
+
+def dsl_field_mutation_to_str(mutation: DSLField) -> str:
+    return print_ast(dsl_gql(DSLMutation(mutation)))
 
 def dsl_exes_to_str(*exes: DSLExecutable) -> str:
     return print_ast(dsl_gql(*exes))

--- a/api/tests/common/__init__.py
+++ b/api/tests/common/__init__.py
@@ -15,10 +15,10 @@ def load_schema() -> GraphQLSchema:
         schema = build_ast_schema(type_def_ast)
         return schema
 
-def dsl_field_query_to_str(query: DSLField) -> str:
+def dsl_field_query_field_to_str(query: DSLField) -> str:
     return print_ast(dsl_gql(DSLQuery(query)))
 
-def dsl_field_mutation_to_str(mutation: DSLField) -> str:
+def dsl_field_mutation_field_to_str(mutation: DSLField) -> str:
     return print_ast(dsl_gql(DSLMutation(mutation)))
 
 def dsl_exes_to_str(*exes: DSLExecutable) -> str:

--- a/api/tests/playbooks/task_definitions.yml
+++ b/api/tests/playbooks/task_definitions.yml
@@ -13,10 +13,22 @@
     - name: Ensure task definitions exist
       lagoon.api.task_definition:
         name: "a test task"
+        project_name: "{{ project_name }}"
         project: "{{ project_id }}"
         task_type: COMMAND
         permission: MAINTAINER
         description: Run my test task
+        service: cli
+        command: ls -l
+
+    - name: Ensure task definitions exist
+      lagoon.api.task_definition:
+        name: "a test task"
+        project_name: "{{ project_name }}"
+        project: "{{ project_id }}"
+        task_type: COMMAND
+        permission: MAINTAINER
+        description: Run my test task foo
         service: cli
         command: ls -l
       register: task_definition_result

--- a/api/tests/playbooks/task_definitions.yml
+++ b/api/tests/playbooks/task_definitions.yml
@@ -28,9 +28,16 @@
         project: "{{ project_id }}"
         task_type: COMMAND
         permission: MAINTAINER
-        description: Run my test task foo
+        description: Run my test task
         service: cli
         command: ls -l
+        advancedTaskDefinitionArguments:
+          - name: MY_CUSTOM_ARG
+            displayName: |-
+              A custom arg to do custom tasks: FULL | HALF-EMPTY -
+              default: FULL
+            defaultValue: FULL
+            type: STRING
       register: task_definition_result
 
     - name: Delete task definition

--- a/api/tests/playbooks/task_definitions.yml
+++ b/api/tests/playbooks/task_definitions.yml
@@ -10,11 +10,6 @@
       ansible.builtin.include_role:
         name: lagoon.api.token
 
-    - name: Delete task definition
-      lagoon.api.task_definition:
-        advancedTaskDefinition: 50
-        state: absent
-
     - name: Ensure task definitions exist
       lagoon.api.task_definition:
         name: "a test task"
@@ -24,3 +19,9 @@
         description: Run my test task
         service: cli
         command: ls -l
+      register: task_definition_result
+
+    - name: Delete task definition
+      lagoon.api.task_definition:
+        advancedTaskDefinition: "{{ task_definition_result.result.id }}"
+        state: absent

--- a/api/tests/playbooks/task_definitions.yml
+++ b/api/tests/playbooks/task_definitions.yml
@@ -1,0 +1,26 @@
+- name: Manipulate task definitions
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  roles:
+    - lagoon.api.common
+  tasks:
+    - name: Create a token.
+      ansible.builtin.include_role:
+        name: lagoon.api.token
+
+    - name: Delete task definition
+      lagoon.api.task_definition:
+        advancedTaskDefinition: 50
+        state: absent
+
+    - name: Ensure task definitions exist
+      lagoon.api.task_definition:
+        name: "a test task"
+        project: "{{ project_id }}"
+        task_type: COMMAND
+        permission: MAINTAINER
+        description: Run my test task
+        service: cli
+        command: ls -l

--- a/api/tests/unit/plugins/module_utils/test_gql.py
+++ b/api/tests/unit/plugins/module_utils/test_gql.py
@@ -27,7 +27,7 @@ class GqlClientTester(unittest.TestCase):
         with self.assertRaises(TypeError) as e:
             client.build_dynamic_query()
 
-        assert(str(e.exception) == "build_dynamic_query() missing 2 required positional arguments: 'query' and 'mainType'")
+        assert("build_dynamic_query() missing 2 required positional arguments: 'query' and 'mainType'" in str(e.exception))
 
         with self.assertRaises(AnsibleValidationError) as e:
             client.build_dynamic_query('projectByName', 'Project')
@@ -53,12 +53,12 @@ class GqlClientTester(unittest.TestCase):
         with self.assertRaises(TypeError) as e:
             client.build_dynamic_mutation()
 
-        assert(str(e.exception) == "build_dynamic_mutation() missing 2 required positional arguments: 'mutation' and 'inputArgs'")
+        assert("build_dynamic_mutation() missing 2 required positional arguments: 'mutation' and 'inputArgs'" in str(e.exception))
 
         with self.assertRaises(TypeError) as e:
             client.build_dynamic_mutation('projectByName')
 
-        assert(str(e.exception) == "build_dynamic_mutation() missing 1 required positional argument: 'inputArgs'")
+        assert("build_dynamic_mutation() missing 1 required positional argument: 'inputArgs'" in str(e.exception))
 
     def test_build_dynamic_mutation_query_instead_of_mutation(self):
         client = GqlClient('foo', 'bar')
@@ -112,7 +112,7 @@ class GqlClientTester(unittest.TestCase):
         with self.assertRaises(TypeError) as e:
             client.mutation_field_add_args()
 
-        assert(str(e.exception) == "mutation_field_add_args() missing 3 required positional arguments: 'mutationField', 'outputType', and 'inputArgs'")
+        assert("mutation_field_add_args() missing 3 required positional arguments: 'mutationField', 'outputType', and 'inputArgs'" in str(e.exception))
 
         # String passed as field.
         with self.assertRaises(TypeError) as e:
@@ -204,7 +204,7 @@ class GqlUtilsTester(unittest.TestCase):
         with self.assertRaises(TypeError) as e:
             field_selector()
 
-        assert(str(e.exception) == "field_selector() missing 3 required positional arguments: 'ds', 'selector', and 'selectorType'")
+        assert("field_selector() missing 3 required positional arguments: 'ds', 'selector', and 'selectorType'" in str(e.exception))
 
         # String passed as DSLSchema.
         with self.assertRaises(TypeError) as e:
@@ -281,7 +281,7 @@ class GqlUtilsTester(unittest.TestCase):
         with self.assertRaises(TypeError) as e:
             nested_field_selector()
 
-        assert(str(e.exception) == "nested_field_selector() missing 4 required positional arguments: 'ds', 'parentType', 'selectFields', and 'leafFields'")
+        assert("nested_field_selector() missing 4 required positional arguments: 'ds', 'parentType', 'selectFields', and 'leafFields'" in str(e.exception))
 
         # String passed as DSLSchema.
         with self.assertRaises(TypeError) as e:
@@ -366,7 +366,7 @@ class GqlProxyLookup(unittest.TestCase):
         with self.assertRaises(TypeError) as e:
             _ = ProxyLookup()
 
-        assert(str(e.exception) == "__init__() missing 1 required positional argument: 'query'")
+        assert("__init__() missing 1 required positional argument: 'query'" in str(e.exception))
 
     def test_hasInputArgs(self):
         GetClientInstance('foo', 'bar').ds = DSLSchema(load_schema())
@@ -391,7 +391,7 @@ class GqlProxyLookup(unittest.TestCase):
         with self.assertRaises(TypeError) as e:
             lookup.execute()
 
-        assert(str(e.exception) == "execute() missing 2 required positional arguments: 'inputArgs' and 'lookupCompareFields'")
+        assert("execute() missing 2 required positional arguments: 'inputArgs' and 'lookupCompareFields'" in str(e.exception))
 
         # String passed as dict.
         lookup = ProxyLookup('projectByName')

--- a/api/tests/unit/plugins/module_utils/test_gql.py
+++ b/api/tests/unit/plugins/module_utils/test_gql.py
@@ -5,7 +5,9 @@ from gql.dsl import DSLField, DSLSchema
 
 import sys
 sys.modules['ansible.utils.display'] = unittest.mock.Mock()
-from .....plugins.module_utils.gql import GqlClient
+from .....plugins.module_utils.gql import (
+  GqlClient, field_selector, input_args_to_field_list, nested_field_selector
+)
 
 
 class GqlClientTester(unittest.TestCase):
@@ -114,21 +116,21 @@ class GqlClientTester(unittest.TestCase):
         with self.assertRaises(TypeError) as e:
             client.mutation_field_add_args('foo', 'bar', 'baz')
 
-        assert(str(e.exception) == "mutationField must be of type DSLField.")
+        assert(str(e.exception) == "mutationField must be of type DSLField, got <class 'str'>.")
 
         # String passed as output type.
         field: DSLField = client.ds.Mutation.addProject
         with self.assertRaises(TypeError) as e:
             client.mutation_field_add_args(field, 'bar', 'baz')
 
-        assert(str(e.exception) == "outputType must be of type GraphQLOutputType.")
+        assert(str(e.exception) == "outputType must be of type GraphQLOutputType, got <class 'str'>.")
 
         # String passed as input args.
         field: DSLField = client.ds.Mutation.addProject
         with self.assertRaises(TypeError) as e:
             client.mutation_field_add_args(field, field.field.type, 'baz')
 
-        assert(str(e.exception) == "inputArgs must be of type dict.")
+        assert(str(e.exception) == "inputArgs must be of type dict, got <class 'str'>.")
 
         # Field does not exist in schema.
         field: DSLField = client.ds.Mutation.addProject
@@ -157,4 +159,202 @@ class GqlClientTester(unittest.TestCase):
         client.mutation_field_add_args(field, field.field.type, {
             'input': {'facts': [{'name': 'foo', 'value': 'bar'}]}})
         assert f"{field}" == 'addFactsByName(input: {facts: [{name: "foo", value: "bar"}]})'
+
+
+class GqlUtilsTester(unittest.TestCase):
+
+    def test_input_args_to_field_list(self):
+        assert input_args_to_field_list({
+            'name': 'foo',
+            'bogusArg': 'bar'
+        }) == ['name', 'bogusArg', 'id']
+
+        assert input_args_to_field_list({
+            'id': 10,
+            'name': 'foo',
+            'bogusArg': 'bar'
+        }) == ['id', 'name', 'bogusArg']
+
+        assert input_args_to_field_list({
+            'id': 10,
+            'name': 'foo',
+            'fact': {'name': 'foo', 'value': 'bar'},
+        }) == ['id', 'name', {'fact': ['name', 'value']}]
+
+        assert input_args_to_field_list({
+            'id': 10,
+            'name': 'foo',
+            'ids': [1, 2, 3],
+        }) == ['id', 'name', 'ids']
+
+        assert input_args_to_field_list({
+            'id': 10,
+            'name': 'foo',
+            'facts': [
+                {'name': 'foo', 'value': 'bar'},
+                {'name': 'baz', 'value': 'qux'}
+            ],
+        }) == ['id', 'name', {'facts': ['name', 'value']}]
+
+    def test_field_selector(self):
+        ds = DSLSchema(load_schema())
+
+        with self.assertRaises(TypeError) as e:
+            field_selector()
+
+        assert(str(e.exception) == "field_selector() missing 3 required positional arguments: 'ds', 'selector', and 'selectorType'")
+
+        # String passed as DSLSchema.
+        with self.assertRaises(TypeError) as e:
+            field_selector('foo', 'bar', 'baz', 'qux')
+
+        assert(str(e.exception) == "ds must be of type DSLSchema, got <class 'str'>.")
+
+        # String passed as field.
+        with self.assertRaises(TypeError) as e:
+            field_selector(ds, 'foo', 'bar', 'baz')
+
+        assert(str(e.exception) == "selector must be of type DSLField, got <class 'str'>.")
+
+        # String passed as output type.
+        field: DSLField = ds.Query.projectByName
+        with self.assertRaises(TypeError) as e:
+            field_selector(ds, field, 'bar', 'baz')
+
+        assert(str(e.exception) == "selectorType must be of type GraphQLOutputType, got <class 'str'>.")
+
+        # String passed as list.
+        field: DSLField = ds.Query.projectByName
+        with self.assertRaises(TypeError) as e:
+            field_selector(ds, field, field.field.type, 'baz')
+
+        assert(str(e.exception) == "selectFields must be of type list, got <class 'str'>.")
+
+        # Scalar type case.
+        field: DSLField = ds.Mutation.deleteProject
+        updated_field = field_selector(ds, field, field.field.type)
+        assert f"{updated_field}" == 'deleteProject'
+
+        # Enum type case.
+        field: DSLField = ds.Project.availability
+        updated_field = field_selector(ds, field, field.field.type)
+        assert f"{updated_field}" == 'availability'
+
+        # List type case.
+        field: DSLField = ds.Project.environments
+        updated_field = field_selector(ds, field, field.field.type, ['id', 'name', 'kubernetesNamespaceName'])
+        assert f"{updated_field}" == """environments {
+  id
+  name
+  kubernetesNamespaceName
+}"""
+
+        # Object type case - inexistent fields are ignored.
+        field: DSLField = ds.Query.projectByName
+        updated_field = field_selector(ds, field, field.field.type, ['id', 'name', 'bogusField'])
+        assert f"{updated_field}" == """projectByName {
+  id
+  name
+}"""
+
+        # Union type case.
+        field: DSLField = ds.Query.advancedTasksForEnvironment
+        updated_field = field_selector(ds, field, field.field.type, ['id', 'name', 'description'])
+        assert f"{updated_field}" == """advancedTasksForEnvironment {
+  ... on AdvancedTaskDefinitionImage {
+    id
+    name
+    description
+  }
+  ... on AdvancedTaskDefinitionCommand {
+    id
+    name
+    description
+  }
+}"""
+
+    def test_nested_field_selector(self):
+        ds = DSLSchema(load_schema())
+
+        with self.assertRaises(TypeError) as e:
+            nested_field_selector()
+
+        assert(str(e.exception) == "nested_field_selector() missing 4 required positional arguments: 'ds', 'parentType', 'selectFields', and 'leafFields'")
+
+        # String passed as DSLSchema.
+        with self.assertRaises(TypeError) as e:
+            nested_field_selector('foo', 'bar', 'baz', 'qux')
+
+        assert(str(e.exception) == "ds must be of type DSLSchema, got <class 'str'>.")
+
+        # String passed as parent type.
+        with self.assertRaises(TypeError) as e:
+            nested_field_selector(ds, 'foo', 'bar', 'baz')
+
+        assert(str(e.exception) == "parentType must be of type DSLType, got <class 'str'>.")
+
+        # String passed as select fields.
+        parent_type = ds.Project
+        with self.assertRaises(TypeError) as e:
+            nested_field_selector(ds, parent_type, 'bar', 'baz')
+
+        assert(str(e.exception) == "selectFields must be of type list, got <class 'str'>.")
+
+        # String passed as leaf fields.
+        parent_type = ds.Project
+        with self.assertRaises(TypeError) as e:
+            nested_field_selector(ds, parent_type, ['bar'], 'baz')
+
+        assert(str(e.exception) == "leafFields must be of type list, got <class 'str'>.")
+
+        # Zero select fields.
+        parent_type = ds.Project
+        with self.assertRaises(AnsibleValidationError) as e:
+            nested_field_selector(ds, parent_type, [], ['id', 'name'])
+
+        assert(str(e.exception) == "selectFields must have at least one field.")
+
+        # Single-level field.
+        parent_type = ds.Project
+        updated_field = nested_field_selector(ds, parent_type, ['environments'], ['id', 'kubernetesNamespaceName'])
+        assert f"{updated_field}" == """environments {
+  id
+  kubernetesNamespaceName
+}"""
+
+        # Multi-level field, list.
+        parent_type = ds.Project
+        updated_field = nested_field_selector(ds, parent_type, ['environments', 'advancedTasks'], ['id', 'name', 'description'])
+        assert f"{updated_field}" == """environments {
+  advancedTasks {
+    ... on AdvancedTaskDefinitionImage {
+      id
+      name
+      description
+    }
+    ... on AdvancedTaskDefinitionCommand {
+      id
+      name
+      description
+    }
+  }
+}"""
+
+        # Multi-level field, non-list.
+        parent_type = ds.Fact
+        updated_field = nested_field_selector(ds, parent_type, ['environment', 'advancedTasks'], ['id', 'name', 'description'])
+        assert f"{updated_field}" == """environment {
+  advancedTasks {
+    ... on AdvancedTaskDefinitionImage {
+      id
+      name
+      description
+    }
+    ... on AdvancedTaskDefinitionCommand {
+      id
+      name
+      description
+    }
+  }
+}"""
 

--- a/api/tests/unit/plugins/module_utils/test_gql.py
+++ b/api/tests/unit/plugins/module_utils/test_gql.py
@@ -1,14 +1,14 @@
 import unittest
 from ansible.module_utils.errors import AnsibleValidationError
-from ....common import dsl_field_query_to_str, load_schema
-from gql.dsl import DSLSchema
+from ....common import dsl_field_mutation_to_str, dsl_field_query_to_str, load_schema
+from gql.dsl import DSLField, DSLSchema
 
 import sys
 sys.modules['ansible.utils.display'] = unittest.mock.Mock()
 from .....plugins.module_utils.gql import GqlClient
 
 
-class GqlTester(unittest.TestCase):
+class GqlClientTester(unittest.TestCase):
 
     def test_client_constructor_missing_args(self):
         with self.assertRaises(TypeError):
@@ -20,13 +20,17 @@ class GqlTester(unittest.TestCase):
     def test_build_dynamic_query_missing_args(self):
         client = GqlClient('foo', 'bar')
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(TypeError) as e:
             client.build_dynamic_query()
 
-        with self.assertRaises(AnsibleValidationError):
+        assert(str(e.exception) == "build_dynamic_query() missing 2 required positional arguments: 'query' and 'mainType'")
+
+        with self.assertRaises(AnsibleValidationError) as e:
             client.build_dynamic_query('projectByName', 'Project')
 
-    def test_build_dynamic_query_missing_args(self):
+        assert(str(e.exception) == "One of fields or subFieldsMap is required.")
+
+    def test_build_dynamic_query(self):
         client = GqlClient('foo', 'bar')
         client.ds = DSLSchema(load_schema())
         query = client.build_dynamic_query('projectByName', 'Project', fields=['id', 'name'])
@@ -38,3 +42,119 @@ class GqlTester(unittest.TestCase):
     name
   }
 }"""
+
+    def test_build_dynamic_mutation_missing_args(self):
+        client = GqlClient('foo', 'bar')
+
+        with self.assertRaises(TypeError) as e:
+            client.build_dynamic_mutation()
+
+        assert(str(e.exception) == "build_dynamic_mutation() missing 2 required positional arguments: 'mutation' and 'inputArgs'")
+
+        with self.assertRaises(TypeError) as e:
+            client.build_dynamic_mutation('projectByName')
+
+        assert(str(e.exception) == "build_dynamic_mutation() missing 1 required positional argument: 'inputArgs'")
+
+    def test_build_dynamic_mutation_query_instead_of_mutation(self):
+        client = GqlClient('foo', 'bar')
+        client.ds = DSLSchema(load_schema())
+
+        with self.assertRaises(AttributeError) as e:
+            client.build_dynamic_mutation('projectByName', inputArgs={'name': 'foo'})
+
+        assert(str(e.exception) == "Field projectByName does not exist in type Mutation.")
+
+    def test_build_dynamic_mutation_wrong_input_format(self):
+        client = GqlClient('foo', 'bar')
+        client.ds = DSLSchema(load_schema())
+
+        with self.assertRaises(KeyError) as e:
+            client.build_dynamic_mutation('addProject', inputArgs={'name': 'foo'})
+
+        assert(str(e.exception) == "'Argument name does not exist in Field: Project.'")
+
+    def test_build_dynamic_mutation(self):
+        client = GqlClient('foo', 'bar')
+        client.ds = DSLSchema(load_schema())
+
+        # No return fields - should use default ['id'].
+        mutation = client.build_dynamic_mutation(
+            'addProject', inputArgs={'input': {'name': 'foo'}})
+        mutation_str = dsl_field_mutation_to_str(mutation)
+        assert mutation_str == """mutation {
+  addProject(input: {name: "foo"}) {
+    id
+  }
+}"""
+
+        # With return fields - inexistent args are ignored.
+        mutation = client.build_dynamic_mutation(
+            'addProject',
+            inputArgs={'input': {'name': 'foo', 'bogusArg': 'bar'}},
+            returnFields=['name', 'kubernetes'])
+        mutation_str = dsl_field_mutation_to_str(mutation)
+        assert mutation_str == """mutation {
+  addProject(input: {name: "foo"}) {
+    name
+    kubernetes
+  }
+}"""
+
+    def test_mutation_field_add_args(self):
+        client = GqlClient('foo', 'bar')
+        client.ds = DSLSchema(load_schema())
+
+        with self.assertRaises(TypeError) as e:
+            client.mutation_field_add_args()
+
+        assert(str(e.exception) == "mutation_field_add_args() missing 3 required positional arguments: 'mutationField', 'outputType', and 'inputArgs'")
+
+        # String passed as field.
+        with self.assertRaises(TypeError) as e:
+            client.mutation_field_add_args('foo', 'bar', 'baz')
+
+        assert(str(e.exception) == "mutationField must be of type DSLField.")
+
+        # String passed as output type.
+        field: DSLField = client.ds.Mutation.addProject
+        with self.assertRaises(TypeError) as e:
+            client.mutation_field_add_args(field, 'bar', 'baz')
+
+        assert(str(e.exception) == "outputType must be of type GraphQLOutputType.")
+
+        # String passed as input args.
+        field: DSLField = client.ds.Mutation.addProject
+        with self.assertRaises(TypeError) as e:
+            client.mutation_field_add_args(field, field.field.type, 'baz')
+
+        assert(str(e.exception) == "inputArgs must be of type dict.")
+
+        # Field does not exist in schema.
+        field: DSLField = client.ds.Mutation.addProject
+        with self.assertRaises(KeyError) as e:
+            client.mutation_field_add_args(field, field.field.type, {'name': 'foo'})
+
+        assert(str(e.exception) == "'Argument name does not exist in Field: Project.'")
+
+        # Scalar type case.
+        field: DSLField = client.ds.Mutation.deleteAdvancedTaskDefinition
+        client.mutation_field_add_args(field, field.field.type, {'advancedTaskDefinition': -980})
+        assert f"{field}" == 'deleteAdvancedTaskDefinition(advancedTaskDefinition: -980)'
+
+        # Object type case.
+        field: DSLField = client.ds.Mutation.addProject
+        client.mutation_field_add_args(field, field.field.type, {'input': {'name': 'foo'}})
+        assert f"{field}" == 'addProject(input: {name: "foo"})'
+
+        # Enum (union) type case.
+        field: DSLField = client.ds.Mutation.addProject
+        client.mutation_field_add_args(field, field.field.type, {'input': {'availability': 'STANDARD'}})
+        assert f"{field}" == 'addProject(input: {availability: STANDARD})'
+
+        # List type case.
+        field: DSLField = client.ds.Mutation.addFactsByName
+        client.mutation_field_add_args(field, field.field.type, {
+            'input': {'facts': [{'name': 'foo', 'value': 'bar'}]}})
+        assert f"{field}" == 'addFactsByName(input: {facts: [{name: "foo", value: "bar"}]})'
+


### PR DESCRIPTION
- Uses the GraphQL schema to dynamically build `argspecs` for validating the action plugin arguments.
  - Significantly reduces the amount of boilerplate code to write and maintain when creating plugins.
  - When new fields are added to the API, they are automatically available in the plugin without any code changes, or in some cases really small ones.
- New mutation plugins can be defined by simply extending `LagoonMutationActionBase` and defining the `actionConfig` attribute.
- Provides a mechanism for automatic lookups of existing records, as well as determining change.

[DEVOPS-602]

[DEVOPS-602]: https://salsadigital.atlassian.net/browse/DEVOPS-602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ