### PR TITLE
[DEVOPS-499] Refactored group to use the MutationActionConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,30 @@ gql-cli https://api.lagoon.amazeeio.cloud/graphql --print-schema \
 
 ## Run unit tests
 ```sh
-docker-compose build test
-docker-compose run --rm test units -v --requirements
+docker compose build test
+docker compose run --rm test units -v --requirements
 ```
 
 ## Creating the docs
 
+To view the module docs in the terminal, run
+```sh
+# List modules
+docker compose run --rm --entrypoint="" -T lint-docs bash -c \
+  'ansible-doc -t module lagoon.api -l'
+
+# Specific module (group)
+docker compose run --rm --entrypoint="" -T lint-docs bash -c \
+  'ansible-doc -t module lagoon.api.group'
+```
+
 Linting the docs
 ```sh
-docker compose build lint-docs
 docker compose run --rm lint-docs
 ```
 
-Build the docs:
+Build & serve the docs:
 ```sh
-docker compose build docs
 docker compose up -d docs
 ```
 

--- a/api/plugins/action/task_definition.py
+++ b/api/plugins/action/task_definition.py
@@ -4,77 +4,80 @@ from ..module_utils.gql import ProxyLookup
 
 class ActionModule(LagoonMutationActionBase):
 
-    actionConfig = MutationActionConfig(
-        name="task_definition",
-        # Configuration for adding a new task definition.
-        add=MutationConfig(
-            # GraphQL Mutation for adding a new task definition.
-            field="addAdvancedTaskDefinition",
-            # GraphQL Mutation for updating an existing task definition.
-            updateField="updateAdvancedTaskDefinition",
-            # Additional arguments to be allowed when calling the action
-            # plugin. These arguments will not be passed to the GraphQL
-            # mutation, but would instead be used to lookup a project by name
-            # in one of the proxy lookups.
-            inputFieldAdditionalArgs=dict(project_name=dict(type="str")),
-            # Aliases for the input fields - in this case used to maintain
-            # compatibility with the previous version of the plugin.
-            inputFieldArgsAliases=dict(
-                advancedTaskDefinitionArguments=["arguments"],
-                deployTokenInjection=["deploy_token_injection"],
-                projectKeyInjection=["project_key_injection"],
-                type=["task_type"],
-            ),
-            # Proxy lookups to be used when looking for existing task
-            # definitions. A first pass is done through the lookups in the
-            # order they are provided, to find one that matches the input
-            # of the plugin. The first one matched is then used to query
-            # task definitions and compare them with the input, using the
-            # lookupCompareFields and diffCompareFields.
-            proxyLookups=[
-                # Will use 'id' if provided to lookup a task definition by id.
-                ProxyLookup(query="advancedTaskDefinitionById"),
-                # Will use 'environment' id if provided to find all task
-                # definitions by environment id, then filter by the fields
-                # in lookupCompareFields.
-                ProxyLookup(query="advancedTasksForEnvironment"),
-                # Will use 'project_name' if provided to find all task
-                # definitions for a project through projectByName, selecting
-                # the fields in selectFields recursively, then filter by the
-                # fields in lookupCompareFields.
-                # This would be similar to the following:
-                #   query {
-                #     projectByName(project_name: "{{ project_name }}") {
-                #       environments {
-                #         advancedTasks {
-                #           id
-                #           ...
-                #         }
-                #       }
-                #     }
-                #   }
-                ProxyLookup(
-                    query="projectByName",
-                    inputArgFields={"project_name": "name"},
-                    selectFields=["environments", "advancedTasks"],
-                ),
-            ],
-            # These fields are used to determine whether the task definition
-            # already exists.
-            lookupCompareFields=["name"],
-            # These fields are used to determine whether the task definition
-            # needs to be updated. If any of the values of these fields are
-            # different between the existing task definition and the input,
-            # the task definition will be updated.
-            diffCompareFields=[
-                "permission",
-                "description",
-                "service",
-                "advancedTaskDefinitionArguments",
-                "deployTokenInjection",
-                "projectKeyInjection",
-            ],
+  actionConfig = MutationActionConfig(
+    name="task_definition",
+    # Configuration for adding a new task definition.
+    add=MutationConfig(
+      # GraphQL Mutation for adding a new task definition.
+      field="addAdvancedTaskDefinition",
+      # GraphQL Mutation for updating an existing task definition.
+      updateField="updateAdvancedTaskDefinition",
+      # Additional arguments to be allowed when calling the action
+      # plugin. These arguments will not be passed to the GraphQL
+      # mutation, but would instead be used to lookup a project by name
+      # in one of the proxy lookups.
+      inputFieldAdditionalArgs=dict(project_name=dict(type="str")),
+      # Aliases for the input fields - in this case used to maintain
+      # compatibility with the previous version of the plugin.
+      inputFieldArgsAliases=dict(
+        advancedTaskDefinitionArguments=["arguments"],
+        deployTokenInjection=["deploy_token_injection"],
+        projectKeyInjection=["project_key_injection"],
+        type=["task_type"],
+      ),
+      # Proxy lookups to be used when looking for existing task
+      # definitions. A first pass is done through the lookups in the
+      # order they are provided, to find one that matches the input
+      # of the plugin. The first one matched is then used to query
+      # task definitions and compare them with the input, using the
+      # lookupCompareFields and diffCompareFields.
+      proxyLookups=[
+        # Will use 'id' if provided to lookup a task definition by id.
+        ProxyLookup(query="advancedTaskDefinitionById"),
+        # Will use 'environment' id if provided to find all task
+        # definitions by environment id, then filter by the fields
+        # in lookupCompareFields.
+        ProxyLookup(query="advancedTasksForEnvironment"),
+        # Will use 'project_name' if provided to find all task
+        # definitions for a project through projectByName, selecting
+        # the fields in selectFields recursively, then filter by the
+        # fields in lookupCompareFields.
+        # This would be similar to the following:
+        #   query {
+        #     projectByName(project_name: "{{ project_name }}") {
+        #       environments {
+        #         advancedTasks {
+        #           id
+        #           ...
+        #         }
+        #       }
+        #     }
+        #   }
+        ProxyLookup(
+          query="projectByName",
+          inputArgFields={"project_name": "name"},
+          selectFields=["environments", "advancedTasks"],
         ),
-        # Configuration for deleting a task definition.
-        delete=MutationConfig(field="deleteAdvancedTaskDefinition"),
-    )
+      ],
+      # These fields are used to determine whether the task definition
+      # already exists.
+      lookupCompareFields=["name"],
+      # These fields are used to determine whether the task definition
+      # needs to be updated. If any of the values of these fields are
+      # different between the existing task definition and the input,
+      # the task definition will be updated.
+      diffCompareFields=[
+        "permission",
+        "description",
+        "service",
+        "advancedTaskDefinitionArguments",
+        "deployTokenInjection",
+        "projectKeyInjection",
+      ],
+    ),
+    # Configuration for deleting a task definition.
+    delete=MutationConfig(
+      field="deleteAdvancedTaskDefinition",
+      proxyLookups=[ProxyLookup(query="advancedTaskDefinitionById")],
+    ),
+  )

--- a/api/plugins/module_utils/argspec.py
+++ b/api/plugins/module_utils/argspec.py
@@ -40,7 +40,7 @@ def generate_argspec_from_mutation(
   for fieldName, arg in mutationField.field.args.items():
     argSpec[fieldName] = generate_argspec_for_input_type(arg.type, aliases)
 
-  if 'input' in argSpec:
+  if 'input' in argSpec and additionalArgs:
     argSpec['input']['options'].update(additionalArgs)
   elif additionalArgs:
     argSpec.update(additionalArgs)
@@ -54,7 +54,7 @@ def generate_argspec_from_input_object_type(
   field: GraphQLInputField
   for fieldName, field in fields.items():
     argSpec[fieldName] = generate_argspec_for_input_type(field.type, aliases)
-    if fieldName in aliases:
+    if aliases and fieldName in aliases:
       argSpec[fieldName]['aliases'] = aliases[fieldName]
   return argSpec
 

--- a/api/plugins/modules/group.py
+++ b/api/plugins/modules/group.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r"""
+module: group
+short_description: Manage groups.
+description:
+  - Manages groups.
+options:
+  name:
+    description:
+      - The name of the group.
+    required: true
+    type: str
+  parentGroup:
+    description:
+      - The name of the fact.
+    required: false
+    type: dict
+    suboptions:
+      id:
+        description: The ID of the parent group.
+        type: int
+      name:
+        description: The name of the parent group.
+        type: str
+  state:
+    description:
+      - Determines if the group should be created or deleted.
+    type: str
+    default: present
+    choices: [ absent, present ]
+"""
+
+EXAMPLES = r"""
+- name: Add a Group
+  lagoon.api.group:
+    name: saas
+
+- name: Delete a Group
+  lagoon.api.group:
+    name: saas
+    state: absent
+"""

--- a/api/tests/common/__init__.py
+++ b/api/tests/common/__init__.py
@@ -28,12 +28,15 @@ def get_mock_gql_client(
         query_return_value: any = None,
         query_dynamic_return_value: any = None) -> GqlClient:
     client = GqlClient('foo', 'bar')
+
     client.execute_query = MagicMock()
     if query_return_value:
         client.execute_query.return_value = query_return_value
+
     client.execute_query_dynamic = MagicMock()
     if query_dynamic_return_value:
         client.execute_query_dynamic.return_value = query_dynamic_return_value
+
     client.client.connect_sync = MagicMock()
     client.client.schema = load_schema()
     client.client.session = SyncClientSession(client=client.client)


### PR DESCRIPTION
Removes the legacy code for Group creation & deletion, and instead uses the new dynamic mutation builder.

- Added docs for the module as well so it can be consistent with the other plugins.