### PR TITLE
[DEVOPS-640] Add wait for mutation action

### DIFF
--- a/api/plugins/action/mutation.py
+++ b/api/plugins/action/mutation.py
@@ -1,7 +1,17 @@
 from . import LagoonActionBase
-from gql.dsl import DSLMutation
+from gql.dsl import DSLMutation, DSLQuery
+from time import sleep
+from typing import Any, Dict
 
 class ActionModule(LagoonActionBase):
+
+    WAIT_QUERIES = {
+        'invokeRegisteredTask': {
+            'query': 'taskById',
+            'matchField': 'id',
+            'statusField': 'status',
+        }
+    }
 
     def run(self, tmp=None, task_vars=None):
 
@@ -16,6 +26,11 @@ class ActionModule(LagoonActionBase):
         mutation = self._task.args.get('mutation')
         mutationArgs = self._task.args.get('arguments')
         subfields = self._task.args.get('subfields', ['id'])
+        wait = self._task.args.get('wait', False)
+        waitCondition = self._task.args.get('waitCondition', {
+            'field': 'status',
+            'value': 'complete',
+        })
 
         with self.client:
             mutationObj = self.client.build_dynamic_mutation(
@@ -23,4 +38,36 @@ class ActionModule(LagoonActionBase):
             res = self.client.execute_query_dynamic(DSLMutation(mutationObj))
             result['result'] = res[mutation]
             result['changed'] = True
+
+            if wait and mutation in self.WAIT_QUERIES:
+                waitQuery = self.WAIT_QUERIES[mutation]
+
+                qryArgs = {}
+                if isinstance(waitQuery["matchField"], str):
+                    qryArgs = {waitQuery["matchField"]: res[mutation][waitQuery["matchField"]]}
+                else:
+                    # Use a dictionary to match differing field names.
+                    pass
+
+                waitQry = self.client.build_dynamic_query(
+                    query=waitQuery["query"],
+                    args=qryArgs,
+                    fields=[waitQuery["statusField"]],
+                )
+                waitResult = self.waitQuery(waitQuery["query"], waitQry, waitCondition)
+                result['wait'] = waitResult
         return result
+
+    def waitQuery(self, qryName, waitQry, waitCondition) -> Dict[str, Any]:
+        waitResult = self.client.execute_query_dynamic(DSLQuery(waitQry))
+
+        while not self.evaluateWaitCondition(qryName, waitResult, waitCondition):
+            sleep(5)
+            waitResult = self.client.execute_query_dynamic(DSLQuery(waitQry))
+
+        return waitResult
+
+    def evaluateWaitCondition(self, qryName, waitResult, waitCondition) -> bool:
+        if waitCondition["field"] in waitResult[qryName]:
+            return waitResult[qryName][waitCondition["field"]] == waitCondition["value"]
+        return False

--- a/api/plugins/action/query.py
+++ b/api/plugins/action/query.py
@@ -14,14 +14,16 @@ class ActionModule(LagoonActionBase):
         self.createClient(task_vars)
 
         query = self._task.args.get('query')
-        mainType = self._task.args.get('mainType')
         args = self._task.args.get('args', {})
         fields = self._task.args.get('fields', [])
         subFields = self._task.args.get('subFields', {})
 
         with self.client:
             queryObj = self.client.build_dynamic_query(
-                query, mainType, args, fields, subFields)
+                query=query,
+                args=args,
+                fields=fields,
+                subFieldsMap=subFields)
             res = self.client.execute_query_dynamic(DSLQuery(queryObj))
             result['result'] = res[query]
         return result

--- a/api/plugins/action/task_definition.py
+++ b/api/plugins/action/task_definition.py
@@ -73,6 +73,8 @@ class ActionModule(LagoonMutationActionBase):
         "advancedTaskDefinitionArguments",
         "deployTokenInjection",
         "projectKeyInjection",
+        "image",
+        "groupName"
       ],
     ),
     # Configuration for deleting a task definition.

--- a/api/plugins/module_utils/gql.py
+++ b/api/plugins/module_utils/gql.py
@@ -149,7 +149,7 @@ class GqlClient(Display):
 
     def build_dynamic_query(self,
                             query: str,
-                            mainType: str,
+                            mainType: str = "",
                             args: Optional[Dict[str, Any]] = {},
                             fields: List[str] = [],
                             subFieldsMap: Optional[Dict[str, List[str]]] = {},
@@ -174,7 +174,6 @@ class GqlClient(Display):
         }
         query = "projectByName"
         args = {"name": "test-project"}
-        mainType = "Project" (since projectByName returns Project)
         fields = ["id", "name"]
         subFieldsMap = {
             "kubernetes": {
@@ -192,6 +191,7 @@ class GqlClient(Display):
         if len(args):
             queryObj.args(**args)
 
+        mainType: str = queryObj.field.type.name
         mainTypeObj: DSLType = getattr(self.ds, mainType)
 
         # Top-level fields.

--- a/api/plugins/modules/mutation.py
+++ b/api/plugins/modules/mutation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 module: mutation
 description: Run a mutation against the Lagoon GraphQL API.
 short_description: Run a mutation against the Lagoon GraphQL API.
@@ -21,9 +21,26 @@ options:
       - The subfields to select from the mutation result.
     type: list
     default: [id]
-'''
+  wait:
+    description:
+      - Whether to wait for the mutation to complete.
+    type: bool
+    default: false
+  waitCondition:
+    description:
+      - The condition to wait for before returning.
+    type: dict
+    default: {field: status, value: complete}
+    suboptions:
+      field:
+        description: The field to use as status.
+        type: str
+      value:
+        description: The value to wait for.
+        type: str
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Delete a Fact via mutation before creating
   lagoon.api.mutation:
     mutation: deleteFact
@@ -68,4 +85,15 @@ EXAMPLES = r'''
           value: 4.0.0
           source: ansible_playbook:audit:module_version
           description: The panelizer module version
-'''
+
+- name: Invoke Lagoon task and wait for completion
+  lagoon.api.mutation:
+    mutation: invokeRegisteredTask
+    arguments:
+      advancedTaskDefinition: -1
+      environment: -1
+      argumentValues:
+        - advancedTaskDefinitionArgumentName: SOME_ARG_NAME
+          value: SOME_ARG_VALUE
+    wait: true
+"""

--- a/api/plugins/modules/query.py
+++ b/api/plugins/modules/query.py
@@ -18,7 +18,8 @@ options:
     default: {}
   mainType:
     description:
-      - The GraphQL type from which to retrieve the top-level fields.
+      - The GraphQL type from which to retrieve the top-level fields - DEPRECATED.
+      - The type is now inferred from the GraphQL schema.
     type: str
   fields:
     description:
@@ -46,7 +47,6 @@ EXAMPLES = r'''
 - name: Query specific fields for all projects.
   lagoon.api.query:
     query: allProjects
-    mainType: Project
     fields:
       - id
       - name
@@ -57,7 +57,6 @@ EXAMPLES = r'''
     query: projectByName
     args:
       name: '{{ project_name }}'
-    mainType: Project
     fields:
       - id
       - name
@@ -76,7 +75,6 @@ EXAMPLES = r'''
     query: projectByName
     args:
       name: '{{ project_name }}'
-    mainType: Project
     subFields:
       envVariables:
         type: EnvKeyValue

--- a/api/tests/unit/plugins/module_utils/test_gql.py
+++ b/api/tests/unit/plugins/module_utils/test_gql.py
@@ -27,7 +27,7 @@ class GqlClientTester(unittest.TestCase):
         with self.assertRaises(TypeError) as e:
             client.build_dynamic_query()
 
-        assert("build_dynamic_query() missing 2 required positional arguments: 'query' and 'mainType'" in str(e.exception))
+        assert("build_dynamic_query() missing 1 required positional argument: 'query'" in str(e.exception))
 
         with self.assertRaises(AnsibleValidationError) as e:
             client.build_dynamic_query('projectByName', 'Project')


### PR DESCRIPTION
This allows us to do things like this directly in a playbook:

```yaml
- name: Invoke PaaS audit Lagoon task
  lagoon.api.mutation:
    mutation: invokeRegisteredTask
    arguments:
      advancedTaskDefinition: 951
      environment: 322422
      argumentValues:
        - advancedTaskDefinitionArgumentName: SHIPSHAPE_AUDIT_NAME
          value: PAAS
    wait: true
  vars:
    lagoon_api_token: "{{ token.token }}"
```