### PR TITLE
DEVOPS-536 - Add missing field to gql query

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           detailed_summary: true
 
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.python-version }}
           path: ansible_collections/lagoon/api/tests/output/junit/*.xml

--- a/api/plugins/lookup/var.py
+++ b/api/plugins/lookup/var.py
@@ -89,7 +89,7 @@ class LookupModule(LagoonLookupBase):
       if environment:
         env_name = term + '-' + environment.replace('/', '-').replace('_', '-').replace('.', '-')
         self._display.v(f"Lagoon variable lookup environment: {env_name}")
-        lagoonEnvironment = Environment(self.client).byNs(env_name, ['id'])
+        lagoonEnvironment = Environment(self.client).byNs(env_name, ['id', 'kubernetesNamespaceName'])
         if not len(lagoonEnvironment.environments):
           raise AnsibleError(
               f"Unable to fetch environment {env_name}; errors: {lagoonEnvironment.errors}")


### PR DESCRIPTION
'kubernetesNamespaceName' is required by the calling function so the field must be returned